### PR TITLE
fix: outfit gender filtering + inferGender correctness

### DIFF
--- a/src/engine/outfitComposer.ts
+++ b/src/engine/outfitComposer.ts
@@ -321,9 +321,11 @@ export function composeOutfits(
 
   if (gender && gender !== 'unisex') {
     const genFiltered = products.filter(p => p.gender === gender || p.gender === 'unisex');
-    if (genFiltered.length > 30) {
+    if (genFiltered.length >= 3) {
       products.length = 0;
       products.push(...genFiltered);
+    } else {
+      return [];
     }
   }
 

--- a/src/engine/productFilter.ts
+++ b/src/engine/productFilter.ts
@@ -42,7 +42,7 @@ const REJECT_NAME_PATTERNS: RegExp[] = [
   /motorsport/i,
   /mini-thuis/i, /mini-uit/i, /thuistenue/i, /uittenue/i, /uitshirt/i, /thuisshirt/i,
 
-  /kaars/i, /candle/i, /\blamp\b/i, /\bvaas\b/i, /\bdecor\b/i,
+  /kaars/i, /candle/i, /lamp/i, /\bvaas\b/i, /\bdecor\b/i,
   /bedrok/i, /\bkussen\b/i, /\bplaid\b/i, /handdoek/i, /baddoek/i,
   /gordijn/i, /laken/i, /dekbed/i, /overtrek/i, /matras/i, /deken/i,
   /vloerkleed/i, /tapijt/i, /\bmok\b/i, /\bbord\b/i, /spiegel/i,

--- a/src/services/bramsFruit/importService.ts
+++ b/src/services/bramsFruit/importService.ts
@@ -106,7 +106,7 @@ function transformCSVToProduct(row: BramsFruitCSVRow): Omit<BramsFruitProduct, '
     product_name: row['Product Name'] || '',
     material_composition: row['Material Composition'] || null,
     barcode: row['Barcode'] || null,
-    gender: row['Gender'] || 'Male',
+    gender: row['Gender'] || 'unisex',
     color_family: row['Color Family'] || '',
     color: row['Color'] || '',
     size: row['Size'] || '',

--- a/src/services/bramsFruit/xlsxParser.ts
+++ b/src/services/bramsFruit/xlsxParser.ts
@@ -335,7 +335,7 @@ function transformRowToProduct(
     product_name: getCell('Product Name'),
     material_composition: getCell('Material Composition') || null,
     barcode: getCell('Barcode') || null,
-    gender: getCell('Gender') || 'Male',
+    gender: getCell('Gender') || 'unisex',
     color_family: getCell('Color Family'),
     color: getCell('Color'),
     size: getCell('Size'),

--- a/src/services/caching/productCacheService.ts
+++ b/src/services/caching/productCacheService.ts
@@ -176,7 +176,7 @@ class ProductCacheService {
 
       // Apply filters
       if (criteria.gender && criteria.gender !== 'unisex') {
-        query = query.or(`gender.eq.${criteria.gender},gender.eq.unisex,gender.is.null`);
+        query = query.or(`gender.eq.${criteria.gender},gender.eq.unisex`);
       }
 
       if (criteria.budget?.max) {

--- a/src/services/data/dataService.ts
+++ b/src/services/data/dataService.ts
@@ -160,12 +160,15 @@ export async function fetchOutfits(_opts?: {
     let allRows: Record<string, any>[] = results.flat();
 
     if (allRows.length < 10) {
-      const { data } = await client
+      let fallbackQ = client
         .from("products")
         .select(selectFields)
         .eq("in_stock", true)
-        .eq("is_kids", false)
-        .limit(400);
+        .eq("is_kids", false);
+      if (_opts?.gender && _opts.gender !== "unisex") {
+        fallbackQ = fallbackQ.or(`gender.eq.${_opts.gender},gender.eq.unisex`);
+      }
+      const { data } = await fallbackQ.limit(400);
       if (data && data.length >= 10) allRows = data;
     }
 

--- a/supabase/functions/import-daisycon-feed/index.ts
+++ b/supabase/functions/import-daisycon-feed/index.ts
@@ -45,8 +45,8 @@ function inferCategory(title, description, categoryPath) {
 
 function inferGender(title, genderTarget, categoryPath) {
   const g = (genderTarget + " " + categoryPath + " " + title).toLowerCase();
-  if (g.includes("female") || g.includes("women") || g.includes("vrouw") || g.includes("dames") || g.includes("girl")) return "female";
-  if (g.includes("male") || g.includes("men") || g.includes("man") || g.includes("heren") || g.includes("boy")) return "male";
+  if (/\b(female|women|woman|vrouw|dames|girl)\b/i.test(g)) return "female";
+  if (/\b(male|men|man|heren|boy)\b/i.test(g)) return "male";
   return "unisex";
 }
 


### PR DESCRIPTION
## Fixes
- inferGender() regex fix: 'woman' wordt nu correct als female herkend (was male door substring match)
- Gender filter threshold van 30 naar 3 in outfitComposer
- Fallback query in dataService heeft nu gender filter
- NULL-gender producten uitgesloten uit cache queries
- Lamp-filter vangt nu ook Nederlandse samengestelde woorden
- BramsFruit default gender van Male naar unisex

## Impact
Voorkomt dat mannen vrouwenkleding zien, lampen in outfits verschijnen, en kinderschoenen worden aanbevolen.