### PR TITLE
fix(engine): 5 outfit-engine bug fixes

### DIFF
--- a/src/engine/colorHarmony.ts
+++ b/src/engine/colorHarmony.ts
@@ -77,25 +77,39 @@ function normalizeColor(color: string): string {
   return color.toLowerCase().trim();
 }
 
+// Split a color string on whitespace, underscore and hyphen so "navy_blue"
+// becomes ["navy", "blue"]. A substring check on the raw string would let
+// "navajo_white" falsely match "navy" (and "tank" match "tan"); matching
+// against tokens only — plus an exact-string fallback for entries that
+// legitimately contain separators such as "off-white" — prevents that.
+function colorTokens(color: string): string[] {
+  return normalizeColor(color).split(/[\s_-]+/).filter(Boolean);
+}
+
+function matchesColorTerm(color: string, term: string): boolean {
+  const c = normalizeColor(color);
+  const t = normalizeColor(term);
+  if (!t) return false;
+  if (c === t) return true;
+  return colorTokens(c).includes(t);
+}
+
 export function isNeutralColor(color: string): boolean {
-  const n = normalizeColor(color);
-  return COLOR_HARMONY_RULES.neutrals.some(x => n.includes(x) || x.includes(n));
+  return COLOR_HARMONY_RULES.neutrals.some(x => matchesColorTerm(color, x));
 }
 
 export function isWarmColor(color: string): boolean {
-  const n = normalizeColor(color);
-  return COLOR_HARMONY_RULES.warm.some(x => n.includes(x) || x.includes(n));
+  return COLOR_HARMONY_RULES.warm.some(x => matchesColorTerm(color, x));
 }
 
 export function isCoolColor(color: string): boolean {
-  const n = normalizeColor(color);
-  return COLOR_HARMONY_RULES.cool.some(x => n.includes(x) || x.includes(n));
+  return COLOR_HARMONY_RULES.cool.some(x => matchesColorTerm(color, x));
 }
 
 function checkMap(c1: string, c2: string, map: Record<string, string[]>): boolean {
   for (const [base, targets] of Object.entries(map)) {
-    if (c1.includes(base) && targets.some(t => c2.includes(t))) return true;
-    if (c2.includes(base) && targets.some(t => c1.includes(t))) return true;
+    if (matchesColorTerm(c1, base) && targets.some(t => matchesColorTerm(c2, t))) return true;
+    if (matchesColorTerm(c2, base) && targets.some(t => matchesColorTerm(c1, t))) return true;
   }
   return false;
 }
@@ -114,8 +128,8 @@ const TONAL_FAMILIES: string[][] = [
 
 function areTonal(c1: string, c2: string): boolean {
   for (const family of TONAL_FAMILIES) {
-    const c1InFamily = family.some(f => c1.includes(f) || f.includes(c1));
-    const c2InFamily = family.some(f => c2.includes(f) || f.includes(c2));
+    const c1InFamily = family.some(f => matchesColorTerm(c1, f));
+    const c2InFamily = family.some(f => matchesColorTerm(c2, f));
     if (c1InFamily && c2InFamily) return true;
   }
   return false;
@@ -129,10 +143,10 @@ export function calculateColorHarmonyScore(color1: string, color2: string): numb
 
   if (isNeutralColor(c1) || isNeutralColor(c2)) return 0.8;
 
-  if ((c1.includes('zwart') && c2.includes('wit')) ||
-      (c1.includes('wit') && c2.includes('zwart')) ||
-      (c1.includes('black') && c2.includes('white')) ||
-      (c1.includes('white') && c2.includes('black'))) {
+  if ((matchesColorTerm(c1, 'zwart') && matchesColorTerm(c2, 'wit')) ||
+      (matchesColorTerm(c1, 'wit') && matchesColorTerm(c2, 'zwart')) ||
+      (matchesColorTerm(c1, 'black') && matchesColorTerm(c2, 'white')) ||
+      (matchesColorTerm(c1, 'white') && matchesColorTerm(c2, 'black'))) {
     return 0.9;
   }
 
@@ -166,17 +180,15 @@ export function calculateOutfitColorHarmony(productColors: string[][]): number {
 }
 
 export function suggestComplementaryColors(color: string): string[] {
-  const n = normalizeColor(color);
   for (const [base, complements] of Object.entries(COLOR_HARMONY_RULES.complementary)) {
-    if (n.includes(base)) return complements;
+    if (matchesColorTerm(color, base)) return complements;
   }
   return COLOR_HARMONY_RULES.neutrals.slice(0, 5);
 }
 
 export function suggestAnalogousColors(color: string): string[] {
-  const n = normalizeColor(color);
   for (const [base, similar] of Object.entries(COLOR_HARMONY_RULES.analogous)) {
-    if (n.includes(base)) return similar;
+    if (matchesColorTerm(color, base)) return similar;
   }
   return COLOR_HARMONY_RULES.neutrals.slice(0, 5);
 }

--- a/src/engine/generateOutfits.ts
+++ b/src/engine/generateOutfits.ts
@@ -556,7 +556,11 @@ function generateOutfitForOccasion(
   const fallbackProducts: Product[] = [];
   const outfitBrands = new Set<string>(usedBrandsGlobal || []);
 
-  for (const category of outfitStructure.requiredCategories) {
+  // Iterate over a snapshot because a successful substitute (e.g. DRESS for TOP)
+  // mutates outfitStructure.requiredCategories to drop the categories it replaces.
+  const requiredCategoriesToProcess = [...outfitStructure.requiredCategories];
+
+  for (const category of requiredCategoriesToProcess) {
     if (selectedCategories.includes(category)) continue;
 
     const selectedProduct = selectProductForCategory(
@@ -594,6 +598,16 @@ function generateOutfitForOccasion(
         const substituteCategories = [ProductCategory.DRESS, ProductCategory.JUMPSUIT];
 
         for (const substituteCategory of substituteCategories) {
+          const replacedCategories = SUBSTITUTE_CATEGORIES[substituteCategory] || [];
+
+          // A DRESS/JUMPSUIT replaces both TOP and BOTTOM. If either of those
+          // already has a real product in the outfit, substituting would create
+          // a conflict (e.g. DRESS + TOP or DRESS + BOTTOM). Skip in that case.
+          const hasConflict = replacedCategories.some(rc =>
+            outfitProducts.some(p => getProductCategory(p) === rc)
+          );
+          if (hasConflict) continue;
+
           const substituteProduct = selectProductForCategory(
             productsByCategory,
             substituteCategory,
@@ -617,11 +631,15 @@ function generateOutfitForOccasion(
             outfitProducts.push(substituteProduct);
             selectedCategories.push(substituteCategory);
 
-            const replacedCategories = SUBSTITUTE_CATEGORIES[substituteCategory] || [];
             replacedCategories.forEach(replacedCategory => {
               if (!selectedCategories.includes(replacedCategory)) {
                 selectedCategories.push(replacedCategory);
               }
+              // Also drop the replaced category from requiredCategories so the
+              // completeness score reflects the effective required set and no
+              // other branch can try to fill it again.
+              const idx = outfitStructure.requiredCategories.indexOf(replacedCategory);
+              if (idx !== -1) outfitStructure.requiredCategories.splice(idx, 1);
             });
 
             console.log(`Used ${substituteCategory} as substitute for ${category}`);

--- a/src/engine/outfitComposer.ts
+++ b/src/engine/outfitComposer.ts
@@ -496,25 +496,34 @@ function buildOutfit(
 ): ComposedOutfit | null {
   const selected: CleanProduct[] = [];
   const selectedBrands = new Set<string>();
+  // Track product IDs already placed in THIS outfit so the same product can
+  // never be selected twice (e.g. as both the top and the optional layer).
+  const selectedIds = new Set<string>();
   const itemCeiling = perItemCeiling(prefs?.budget);
 
+  const addSelected = (p: CleanProduct) => {
+    selected.push(p);
+    selectedBrands.add(p.brand.toLowerCase());
+    selectedIds.add(p.id);
+  };
+
   for (const cat of blueprint.required) {
-    let pool = (byCategory[cat] || []).filter(p => !usedIds.has(p.id) && p.price >= blueprint.priceFloor);
+    let pool = (byCategory[cat] || []).filter(p =>
+      !usedIds.has(p.id) && !selectedIds.has(p.id) && p.price >= blueprint.priceFloor
+    );
     pool = budgetFilterPool(pool, itemCeiling);
     if (pool.length === 0) {
-      let fallbackPool = (byCategory[cat] || []).filter(p => !usedIds.has(p.id));
+      let fallbackPool = (byCategory[cat] || []).filter(p => !usedIds.has(p.id) && !selectedIds.has(p.id));
       fallbackPool = budgetFilterPool(fallbackPool, itemCeiling);
       if (fallbackPool.length === 0) return null;
       const pick = pickBest(fallbackPool, blueprint, archetype, seed + cat.length, selectedBrands, selected, prefs, diversityTracker, isRepeatedOccasion);
       if (!pick) return null;
-      selected.push(pick);
-      selectedBrands.add(pick.brand.toLowerCase());
+      addSelected(pick);
       continue;
     }
     const pick = pickBest(pool, blueprint, archetype, seed + cat.length, selectedBrands, selected, prefs, diversityTracker, isRepeatedOccasion);
     if (!pick) return null;
-    selected.push(pick);
-    selectedBrands.add(pick.brand.toLowerCase());
+    addSelected(pick);
   }
 
   const topId = selected.find(p => p.category === 'top')?.id || '';
@@ -522,13 +531,22 @@ function buildOutfit(
   const comboKey = `${topId}-${bottomId}`;
   if (usedCombos.has(comboKey)) {
     let altPool = (byCategory['bottom'] || [])
-      .filter(p => !usedIds.has(p.id) && p.id !== bottomId && p.price >= blueprint.priceFloor);
+      .filter(p =>
+        !usedIds.has(p.id)
+        && !selectedIds.has(p.id)
+        && p.id !== bottomId
+        && p.price >= blueprint.priceFloor
+      );
     altPool = budgetFilterPool(altPool, itemCeiling);
     const altBottom = altPool
       .sort((a, b) => scoreProduct(b, blueprint, archetype, selectedBrands, selected, prefs) - scoreProduct(a, blueprint, archetype, selectedBrands, selected, prefs))[0];
     if (altBottom) {
       const idx = selected.findIndex(p => p.category === 'bottom');
-      if (idx >= 0) selected[idx] = altBottom;
+      if (idx >= 0) {
+        selectedIds.delete(selected[idx].id);
+        selected[idx] = altBottom;
+        selectedIds.add(altBottom.id);
+      }
     }
   }
 
@@ -537,14 +555,13 @@ function buildOutfit(
 
   for (const cat of blueprint.optional) {
     let pool = (byCategory[cat] || []).filter(p =>
-      !usedIds.has(p.id) && p.price >= blueprint.priceFloor
+      !usedIds.has(p.id) && !selectedIds.has(p.id) && p.price >= blueprint.priceFloor
     );
     pool = budgetFilterPool(pool, itemCeiling);
     if (pool.length === 0) continue;
     const pick = pickBest(pool, blueprint, archetype, seed + cat.length * 3, selectedBrands, selected, prefs, diversityTracker, isRepeatedOccasion);
     if (pick) {
-      selected.push(pick);
-      selectedBrands.add(pick.brand.toLowerCase());
+      addSelected(pick);
     }
   }
 
@@ -559,6 +576,7 @@ function buildOutfit(
         const altPool = (byCategory[swapCat] || [])
           .filter(p =>
             !usedIds.has(p.id)
+            && !selectedIds.has(p.id)
             && p.id !== currentItem.id
             && (p.subType || p.category) !== (currentItem.subType || currentItem.category)
           );
@@ -566,7 +584,11 @@ function buildOutfit(
         const alt = pickBest(altPool, blueprint, archetype, seed + swapCat.length * 7, selectedBrands, selected, prefs, diversityTracker, isRepeatedOccasion);
         if (alt) {
           const idx = selected.indexOf(currentItem);
-          if (idx >= 0) selected[idx] = alt;
+          if (idx >= 0) {
+            selectedIds.delete(currentItem.id);
+            selected[idx] = alt;
+            selectedIds.add(alt.id);
+          }
           break;
         }
       }

--- a/src/engine/outfitComposer.ts
+++ b/src/engine/outfitComposer.ts
@@ -500,6 +500,7 @@ function buildOutfit(
   // never be selected twice (e.g. as both the top and the optional layer).
   const selectedIds = new Set<string>();
   const itemCeiling = perItemCeiling(prefs?.budget);
+  const budgetMax = prefs?.budget && prefs.budget.max > 0 ? prefs.budget.max : Infinity;
 
   const addSelected = (p: CleanProduct) => {
     selected.push(p);
@@ -561,6 +562,9 @@ function buildOutfit(
     if (pool.length === 0) continue;
     const pick = pickBest(pool, blueprint, archetype, seed + cat.length * 3, selectedBrands, selected, prefs, diversityTracker, isRepeatedOccasion);
     if (pick) {
+      // Reject the addition if it would push the outfit over the user's budget.
+      const projectedTotal = selected.reduce((s, p) => s + p.price, 0) + pick.price;
+      if (projectedTotal > budgetMax) continue;
       addSelected(pick);
     }
   }
@@ -598,6 +602,11 @@ function buildOutfit(
   for (const p of selected) usedIds.add(p.id);
 
   const totalPrice = selected.reduce((s, p) => s + p.price, 0);
+  // Final budget guard: the sum of all selected items must fit within the
+  // user's max budget. Items individually passing the per-item ceiling can
+  // still combine past the outfit total.
+  if (totalPrice > budgetMax) return null;
+
   const coverProduct = selected.find(p => p.category === 'outerwear')
     || selected.find(p => p.category === 'top')
     || selected[0];

--- a/src/engine/outfitComposer.ts
+++ b/src/engine/outfitComposer.ts
@@ -1,6 +1,8 @@
 import { isAdultClothingProduct, classifyCategory } from './productFilter';
 import { matchesColorSeason } from './colorSeasonFiltering';
 import { deriveAthleticIntent as _deriveAthleticIntentFromEnricher } from './productEnricher';
+import { getCurrentSeason } from './helpers';
+import type { Season } from './types';
 
 export interface CleanProduct {
   id: string;
@@ -16,6 +18,7 @@ export interface CleanProduct {
   description: string;
   retailer: string;
   tags: string[];
+  seasons: Season[];
   athleticIntent?: number;
   subType?: string;
   itemReason?: string;
@@ -261,6 +264,59 @@ export interface UserPreferences {
   occasions?: string[];
   colorProfile?: { season?: string; temperature?: string; value?: string; contrast?: string };
   budget?: { min: number; max: number };
+  season?: Season;
+}
+
+// Keyword heuristics for detecting clearly season-bound items. These are
+// intentionally conservative — we only reject an item when its name or
+// description strongly signals a single season.
+const SEASON_ONLY_PATTERNS: Record<Season, RegExp[]> = {
+  winter: [
+    /winterjas/i, /winter coat/i, /\bpuffer\b/i, /down\s*jacket/i, /donsjack/i,
+    /parka/i, /teddy/i, /sherpa/i, /fleece(?!.*short)/i, /gevoerd/i,
+    /thermisch/i, /thermal/i, /coltrui/i, /turtleneck/i,
+  ],
+  summer: [
+    /\bshort(s)?\b/i, /korte broek/i, /zwembroek/i, /swim\s*short/i,
+    /bikini/i, /tankini/i, /zwempak/i, /\bsandaal\b/i, /\bsandal\b/i,
+    /\bslipper(s)?\b/i, /flip.?flop/i, /teenslipper/i, /linnen short/i,
+  ],
+  spring: [],
+  autumn: [],
+};
+
+function detectProductSeasons(
+  raw: Record<string, any>,
+  name: string,
+  description: string,
+): Season[] {
+  // Prefer explicit season data from the row when available.
+  const rawSeason = raw.season ?? raw.seasons;
+  if (Array.isArray(rawSeason)) {
+    const valid = rawSeason
+      .map(s => String(s).toLowerCase())
+      .filter((s): s is Season => s === 'spring' || s === 'summer' || s === 'autumn' || s === 'winter');
+    if (valid.length > 0) return valid;
+  } else if (typeof rawSeason === 'string' && rawSeason.trim() !== '') {
+    const s = rawSeason.toLowerCase();
+    if (s === 'spring' || s === 'summer' || s === 'autumn' || s === 'winter') {
+      return [s];
+    }
+  }
+
+  // Fall back to keyword-based inference.
+  const text = `${name} ${description}`.toLowerCase();
+  const inferred: Season[] = [];
+  (['winter', 'summer'] as Season[]).forEach(s => {
+    if (SEASON_ONLY_PATTERNS[s].some(r => r.test(text))) inferred.push(s);
+  });
+  return inferred;
+}
+
+function isProductInSeason(p: CleanProduct, season: Season): boolean {
+  // No explicit season tags → item is considered season-neutral.
+  if (!p.seasons || p.seasons.length === 0) return true;
+  return p.seasons.includes(season);
 }
 
 const OCCASION_QUIZ_TO_COMPOSER: Record<string, string> = {
@@ -295,13 +351,17 @@ export function composeOutfits(
   count: number,
   gender?: string,
   prefs?: UserPreferences,
+  season?: Season,
 ): ComposedOutfit[] {
+  const activeSeason: Season = season ?? prefs?.season ?? getCurrentSeason();
   const clean = rawRows.filter(isAdultClothingProduct);
 
   const products: CleanProduct[] = clean.map(r => {
+    const name = r.name || r.title || '';
+    const description = r.description || '';
     const base: CleanProduct = {
       id: r.id,
-      name: r.name || r.title || '',
+      name,
       brand: r.brand || '',
       price: typeof r.price === 'number' ? r.price : parseFloat(r.price) || 0,
       imageUrl: r.image_url || r.imageUrl || '',
@@ -310,14 +370,17 @@ export function composeOutfits(
       colors: Array.isArray(r.colors) ? r.colors : [],
       style: r.style || 'casual',
       gender: r.gender || 'unisex',
-      description: r.description || '',
+      description,
       retailer: r.retailer || '',
       tags: Array.isArray(r.tags) ? r.tags : [],
+      seasons: detectProductSeasons(r, name, description),
     };
     base.athleticIntent = deriveAthleticIntent(base);
     base.subType = classifySubType(base);
     return base;
-  }).filter(p => p.category !== 'other' && p.imageUrl && p.url);
+  })
+    .filter(p => p.category !== 'other' && p.imageUrl && p.url)
+    .filter(p => isProductInSeason(p, activeSeason));
 
   if (gender && gender !== 'unisex') {
     const genFiltered = products.filter(p => p.gender === gender || p.gender === 'unisex');


### PR DESCRIPTION
## Summary

Fixes 5 distinct bugs in the outfit generation engine. Each bug is isolated in its own commit for easy review and revert.

## Bugs fixed

- **c2af92e9 — Bug 1: DRESS/JUMPSUIT substitute conflict** (`src/engine/generateOutfits.ts`)
  When a DRESS substituted for a failed TOP, BOTTOM remained in `requiredCategories` and a pants item was still added, producing outfits with both a dress and pants. Fix: iterate over a snapshot, check for category conflicts before substituting, and remove replaced categories from `requiredCategories` after a successful substitute.

- **0bd3e4a5 — Bug 2: Season awareness** (`src/engine/outfitComposer.ts`)
  No season filtering, so winter coats could appear alongside shorts. Fix: add `SEASON_ONLY_PATTERNS`, `detectProductSeasons()` and `isProductInSeason()`; default to `getCurrentSeason()` when no season is passed. Optional `season` parameter on `composeOutfits` preserves the existing API.

- **17c00dad — Bug 5: Duplicate product IDs within an outfit** (`src/engine/outfitComposer.ts`)
  The same product could appear multiple times in one outfit. Fix: `selectedIds: Set<string>` in `buildOutfit` tracks picks; every pool filters `!selectedIds.has(p.id)` and swap ops update the set.

- **e8fded55 — Bug 3: Budget-total enforcement** (`src/engine/outfitComposer.ts`)
  Only per-item price ceilings were applied, so 3×€60 passed a €100 max. Fix: track running `totalPrice` and reject outfits where the cumulative total exceeds `prefs.budget.max`.

- **7f044d20 — Bug 4: Color substring false matches** (`src/engine/colorHarmony.ts`)
  `\"navajo_white\".includes(\"navy\")` and similar substring matches produced false harmony results. Fix: tokenize colors on whitespace/underscore/hyphen and match with an exact-string fallback. Preserves Dutch compound colors like \"donkerblauw\" that are listed as their own entries.

## Test plan

- [x] `npm run build` succeeds
- [ ] Generate outfits with `budget.max = 100` — verify no outfit exceeds €100 total
- [ ] Force winter season — verify no shorts/sandals; force summer — verify no puffer/parka
- [ ] Inspect generated outfits — no duplicate product IDs, no dress+pants combos
- [ ] Unit-check color harmony: `calculateColorHarmonyScore(\"navajo_white\", \"red\")` no longer matches the navy rule