### PR TITLE
Remove registration wall blocking quiz access

### DIFF
--- a/src/components/results/SaveOutfitsModal.tsx
+++ b/src/components/results/SaveOutfitsModal.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Save, ArrowRight, Sparkles } from 'lucide-react';
+import { X, Save, ArrowRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from '@/context/UserContext';
 
@@ -13,17 +13,17 @@ interface SaveOutfitsModalProps {
 export function SaveOutfitsModal({ isOpen, onClose, outfitCount = 12 }: SaveOutfitsModalProps) {
   const navigate = useNavigate();
   const { user } = useUser();
-  const [isLoading, setIsLoading] = useState(false);
 
-  const handleSave = async () => {
-    setIsLoading(true);
-
+  const handleRegister = () => {
     if (user) {
       onClose();
       return;
     }
-
     navigate('/registreren?from=results&action=save');
+  };
+
+  const handleLogin = () => {
+    navigate('/inloggen?from=results&action=save');
   };
 
   if (!isOpen) return null;
@@ -110,36 +110,33 @@ export function SaveOutfitsModal({ isOpen, onClose, outfitCount = 12 }: SaveOutf
             {/* CTAs */}
             <div className="space-y-3">
               <button
-                onClick={handleSave}
-                disabled={isLoading}
-                className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-[var(--ff-color-primary-700)] hover:bg-[var(--ff-color-primary-600)] text-white rounded-xl font-semibold text-base transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleRegister}
+                className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#C2654A] hover:bg-[#A8513A] text-white rounded-xl font-semibold text-base transition-colors duration-200"
               >
-                {isLoading ? (
-                  <>
-                    <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                    Even geduld...
-                  </>
-                ) : (
-                  <>
-                    <Save className="w-5 h-5" />
-                    Opslaan (gratis)
-                    <ArrowRight className="w-5 h-5" />
-                  </>
-                )}
+                <Save className="w-5 h-5" />
+                Maak gratis account
+                <ArrowRight className="w-5 h-5" />
+              </button>
+
+              <button
+                onClick={handleLogin}
+                className="w-full px-6 py-3 bg-white border border-[#E5E5E5] hover:border-[#C2654A] text-[#1A1A1A] rounded-xl font-medium text-base transition-colors duration-200"
+              >
+                Heb je al een account? Log in
               </button>
 
               <button
                 onClick={onClose}
-                className="w-full px-8 py-3 text-[var(--color-muted)] hover:text-[var(--color-text)] font-medium transition-colors"
+                className="w-full px-8 py-2 text-[#8A8A8A] hover:text-[#1A1A1A] font-medium text-sm transition-colors"
               >
                 Nee, bedankt
               </button>
             </div>
 
             {/* Privacy note */}
-            <p className="text-xs text-center text-[var(--color-muted)] mt-6 flex items-center justify-center gap-2">
+            <p className="text-xs text-center text-[#8A8A8A] mt-6 flex items-center justify-center gap-2">
               <span className="text-[#C2654A]">🔒</span>
-              Gratis account • Geen betaalgegevens nodig • 
+              Gratis account • Geen betaalgegevens nodig
             </p>
           </div>
         </motion.div>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -13,7 +13,6 @@ import {
   Lock,
   Info,
 } from "lucide-react";
-import { useUser } from "@/context/UserContext";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabaseClient";
 import { useTestimonials } from "@/hooks/useTestimonials";
@@ -53,7 +52,6 @@ const marqueeCSS = `
 `;
 
 export default function LandingPage() {
-  const { user } = useUser();
   const navigate = useNavigate();
 
   /* Preserve existing data-fetching */
@@ -76,7 +74,7 @@ export default function LandingPage() {
   const { testimonials } = useTestimonials();
 
   const handleStartClick = () => {
-    navigate(user ? "/onboarding" : "/registreren");
+    navigate("/onboarding");
   };
 
   const handleExampleClick = () => {


### PR DESCRIPTION
## Summary
- Removed the redirect that sent anonymous users from the landing page to `/registreren` before they could start the quiz. The "Begin gratis" CTA now goes straight to `/onboarding` for everyone.
- Quiz, moodboard swipes and results were already accessible without an account (data persists in localStorage; Supabase sync is opt-in for logged-in users).
- `SaveOutfitsModal` is now the conversion moment after users have seen value: it offers both **Maak gratis account** (primary) and **Log in** (secondary) inline, instead of one button that redirected away from the results page.

## Why
Forcing registration before the quiz was the #1 conversion killer — users had to commit before getting anything. They now experience the full landing → quiz → moodboard → results flow first, then are asked to register only when they want to save/share.

## Test plan
- [ ] Landing page → click "Begin gratis" while logged out → lands on `/onboarding` (no redirect)
- [ ] Complete all 13 quiz steps + moodboard swipes anonymously
- [ ] Results page renders all outfits without an account
- [ ] On exit-intent, `SaveOutfitsModal` opens with both register and login CTAs
- [ ] Clicking "Maak gratis account" goes to `/registreren?from=results&action=save`
- [ ] Clicking "Log in" goes to `/inloggen?from=results&action=save`
- [ ] `npm run build` succeeds (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)