### PR TITLE
feat(ci): vitest tests, GitHub Actions workflow, typecheck gate prep

### DIFF
--- a/.github/workflows-proposed/README.md
+++ b/.github/workflows-proposed/README.md
@@ -1,0 +1,22 @@
+# Proposed workflows
+
+This folder holds CI workflow files that were prepared but could not be pushed
+directly because the OAuth token used by the agent that created this branch
+does not carry the `workflow` scope.
+
+To activate a workflow:
+
+```bash
+mkdir -p .github/workflows
+git mv .github/workflows-proposed/<name>.yml .github/workflows/<name>.yml
+```
+
+Then push with a token that has the `workflow` scope (or move the file via the
+GitHub web UI, which handles the scope for you).
+
+## Files
+
+- `ci.yml` — Runs `npm ci`, `npm run typecheck`, `npm test`, `npm run build`
+  on every push to `main` and every PR. Typecheck is currently
+  `continue-on-error: true` because the codebase has pre-existing type
+  errors; tests and build are hard gates.

--- a/.github/workflows-proposed/ci.yml
+++ b/.github/workflows-proposed/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Typecheck, tests & build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Full-project typecheck runs but does not fail the build yet: the
+      # codebase carries pre-existing type errors that are tracked separately.
+      # Once those are resolved, remove `continue-on-error` to make this a hard
+      # gate.
+      - name: Typecheck (informational)
+        run: npm run typecheck
+        continue-on-error: true
+
+      - name: Unit tests (vitest)
+        run: npm test
+
+      - name: Build (vite)
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,11 @@ coverage/
 playwright-report/
 test-results/
 
+# ...but do track the committed vitest unit tests
+!src/__tests__/
+!src/__tests__/**
+!vitest.config.ts
+
 # Development and debugging
 __trash_review/
 *_REPORT.md

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,5 +10,14 @@ fi
 
 echo '✅ Geen Python headers gevonden in frontend code'
 
+# Run unit tests — fast gate voor de testable modules (engine/*)
+if [ -f "node_modules/.bin/vitest" ]; then
+  echo '🧪 Running vitest unit tests...'
+  if ! node_modules/.bin/vitest run --reporter=dot; then
+    echo '❌ Unit tests gefaald – commit geweigerd'
+    exit 1
+  fi
+fi
+
 # Run lint-staged
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,17 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@types/node": "^20.12.0",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.4.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^3.4.0",
         "terser": "^5.44.1",
         "typescript": "^5.9.2",
-        "vite": "^5.4.20"
+        "vite": "^5.4.20",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": "20.x"
@@ -1364,12 +1368,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/phoenix": {
@@ -1377,6 +1381,34 @@
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
       "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1406,6 +1438,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -1457,6 +1602,16 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -1572,6 +1727,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1614,6 +1779,33 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1729,6 +1921,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1749,6 +1951,13 @@
       "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1797,6 +2006,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -2144,6 +2373,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2161,6 +2397,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -2282,6 +2528,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2780,6 +3043,13 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2822,6 +3092,20 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2956,6 +3240,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2984,6 +3282,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3027,9 +3355,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3128,6 +3456,112 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "preinstall": "node scripts/bolt-install.mjs",
     "typecheck": "tsc --noEmit --pretty",
     "build:strict": "npm run typecheck && vite build",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:smoke": "playwright test tests/visual/nova-sse-health.spec.ts --headed",
@@ -43,12 +44,16 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@types/node": "^20.12.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "terser": "^5.44.1",
     "typescript": "^5.9.2",
-    "vite": "^5.4.20"
+    "vite": "^5.4.20",
+    "vitest": "^2.1.9"
   }
 }

--- a/scripts/bolt-install.mjs
+++ b/scripts/bolt-install.mjs
@@ -6,10 +6,43 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
 pkg.devDependencies ||= {};
 pkg.scripts ||= {};
 
-// 1) Zware dev-tooling eruit die Bolt niet nodig heeft
-const HEAVY = /^(eslint|@eslint|prettier|husky|lint-?staged|cypress|storybook|jest|vitest|playwright|webpack|rollup|babel|ts-node|@types\/)/i;
-for (const name of Object.keys(pkg.devDependencies)) {
-  if (HEAVY.test(name)) delete pkg.devDependencies[name];
+// Buiten Bolt (lokaal, CI) laten we de volledige devDependencies staan,
+// anders kan `tsc --noEmit` of `vitest` niet draaien op GitHub Actions.
+const isBolt =
+  process.env.BOLT === "1" ||
+  process.env.STACKBLITZ === "1" ||
+  process.env.BOLT_ENV === "1" ||
+  (typeof process.env.npm_config_user_agent === "string" &&
+    process.env.npm_config_user_agent.includes("bolt"));
+
+// 1) Zware dev-tooling die Bolt niet nodig heeft, maar die we elders wél willen.
+// Let op: @types/react en @types/react-dom NIET strippen — tsconfig.json verwijst er
+// expliciet naar, en zonder die types faalt typecheck op elk JSX-bestand.
+const HEAVY =
+  /^(eslint|@eslint|prettier|husky|lint-?staged|cypress|storybook|jest|playwright|webpack|rollup|babel|ts-node)/i;
+const TYPES_ALLOWLIST = new Set([
+  "@types/react",
+  "@types/react-dom",
+  "@types/node",
+]);
+
+if (isBolt) {
+  for (const name of Object.keys(pkg.devDependencies)) {
+    if (TYPES_ALLOWLIST.has(name)) continue;
+    if (HEAVY.test(name)) {
+      delete pkg.devDependencies[name];
+      continue;
+    }
+    // Overige @types/* strippen voor Bolt (niet nodig at runtime)
+    if (/^@types\//.test(name)) {
+      delete pkg.devDependencies[name];
+      continue;
+    }
+    // Vitest strippen in Bolt — buiten Bolt houden we het voor CI
+    if (/^vitest(\b|$)/.test(name) || /^@vitest\//.test(name)) {
+      delete pkg.devDependencies[name];
+    }
+  }
 }
 
 // 2) Zorg dat Vite + React plugin + TS blijven werken in Bolt
@@ -24,7 +57,12 @@ pkg.devDependencies.autoprefixer ??= "^10.4.0";
 if (pkg.scripts.prepare) pkg.scripts.prepare = "echo 'husky skipped (Bolt)'";
 
 // 4) Engines advies
-pkg.engines ||= {}; pkg.engines.node = "20.x";
+pkg.engines ||= {};
+pkg.engines.node = "20.x";
 
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
-console.log("✅ bolt-install: trimmed dev deps; husky off; engines=20.x");
+console.log(
+  isBolt
+    ? "✅ bolt-install: trimmed dev deps for Bolt; husky off; engines=20.x"
+    : "✅ bolt-install: non-Bolt env — devDeps preserved for CI; engines=20.x"
+);

--- a/src/__tests__/engine/calculateMatchScore.test.ts
+++ b/src/__tests__/engine/calculateMatchScore.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateMatchPercentage,
+  calculateMatchScore,
+} from "@/engine/calculateMatchScore";
+import type { Product, StylePreferences } from "@/engine/types";
+
+const prefs: StylePreferences = {
+  casual: 3,
+  formal: 1,
+  sporty: 0,
+  vintage: 2,
+  minimalist: 5,
+};
+
+function makeProduct(styleTags: string[]): Product {
+  return {
+    id: "p",
+    name: "test",
+    styleTags,
+  };
+}
+
+describe("calculateMatchScore", () => {
+  it("returns 0 when the product has no style tags", () => {
+    expect(calculateMatchScore(makeProduct([]), prefs)).toBe(0);
+  });
+
+  it("sums matching style tag preferences (case-insensitive)", () => {
+    const product = makeProduct(["Casual", "MINIMALIST"]);
+    expect(calculateMatchScore(product, prefs)).toBe(3 + 5);
+  });
+
+  it("differs when preferences differ — not hardcoded", () => {
+    const product = makeProduct(["casual", "formal"]);
+    const weighted = calculateMatchScore(product, prefs);
+    const flipped: StylePreferences = {
+      ...prefs,
+      casual: 10,
+      formal: 0,
+    };
+    expect(calculateMatchScore(product, flipped)).toBeGreaterThan(weighted);
+  });
+
+  it("ignores tags that do not match any preference key", () => {
+    expect(calculateMatchScore(makeProduct(["unknown-tag"]), prefs)).toBe(0);
+  });
+});
+
+describe("calculateMatchPercentage", () => {
+  it("maps a raw score to a 0-100 percentage", () => {
+    expect(calculateMatchPercentage(5, 10)).toBe(50);
+  });
+
+  it("clamps the percentage to at most 100", () => {
+    expect(calculateMatchPercentage(9999, 10)).toBe(100);
+  });
+
+  it("clamps the percentage to at least 0", () => {
+    expect(calculateMatchPercentage(-5, 10)).toBe(0);
+  });
+
+  it("returns 0 when maxPossibleScore is 0 or negative", () => {
+    expect(calculateMatchPercentage(7, 0)).toBe(0);
+    expect(calculateMatchPercentage(7, -3)).toBe(0);
+  });
+});

--- a/src/__tests__/engine/outfitComposer.test.ts
+++ b/src/__tests__/engine/outfitComposer.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { composeOutfits } from "@/engine/outfitComposer";
+
+type RawRow = Record<string, unknown>;
+
+const CATALOG_BRANDS = [
+  "COS",
+  "ARKET",
+  "Uniqlo",
+  "Filippa K",
+  "Drykorn",
+  "Boss",
+  "Profuomo",
+  "Cavallaro",
+  "Blue Industry",
+  "PME",
+  "State of Art",
+  "Cast Iron",
+];
+
+function mkProduct(
+  id: string,
+  overrides: Partial<Record<string, unknown>> = {},
+): RawRow {
+  return {
+    id,
+    name: "Slim fit katoenen overhemd wit",
+    brand: "COS",
+    price: 79.95,
+    image_url: `https://example.com/${id}.jpg`,
+    affiliate_url: `https://partner.example/${id}`,
+    category: "top",
+    colors: ["wit"],
+    style: "smart-casual",
+    gender: "male",
+    description: "Regular fit katoen overhemd",
+    retailer: "example",
+    tags: ["katoen"],
+    ...overrides,
+  };
+}
+
+function buildCatalog(size = 40): RawRow[] {
+  const rows: RawRow[] = [];
+  for (let i = 0; i < size; i++) {
+    const brand = CATALOG_BRANDS[i % CATALOG_BRANDS.length];
+
+    rows.push(
+      mkProduct(`top-${i}`, {
+        name: i % 2 === 0 ? "Katoenen overhemd wit" : "Merino crewneck sweater navy",
+        brand,
+        category: "top",
+        price: 45 + (i % 4) * 20,
+        colors: i % 2 === 0 ? ["wit"] : ["navy"],
+        style: i % 3 === 0 ? "smart-casual" : "casual",
+      }),
+    );
+
+    rows.push(
+      mkProduct(`bottom-${i}`, {
+        name: i % 2 === 0 ? "Slim fit chino beige" : "Regular fit jeans donkerblauw",
+        brand,
+        category: "bottom",
+        price: 55 + (i % 5) * 15,
+        colors: i % 2 === 0 ? ["beige"] : ["donkerblauw"],
+        style: i % 2 === 0 ? "smart-casual" : "casual",
+      }),
+    );
+
+    rows.push(
+      mkProduct(`footwear-${i}`, {
+        name: i % 2 === 0 ? "Leren derby schoen bruin" : "Witte sneaker",
+        brand,
+        category: "footwear",
+        price: 85 + (i % 6) * 20,
+        colors: i % 2 === 0 ? ["bruin"] : ["wit"],
+        style: i % 2 === 0 ? "smart-casual" : "casual",
+      }),
+    );
+
+    rows.push(
+      mkProduct(`outerwear-${i}`, {
+        name: "Wollen blazer navy",
+        brand,
+        category: "outerwear",
+        price: 149 + (i % 3) * 30,
+        colors: ["navy"],
+        style: "smart-casual",
+      }),
+    );
+  }
+  return rows;
+}
+
+describe("composeOutfits", () => {
+  it("returns an empty array when there are no products", () => {
+    const result = composeOutfits([], "MINIMALIST", 3);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array when a required category pool is missing", () => {
+    const rows = buildCatalog(10).filter((r) => r.category !== "footwear");
+    const result = composeOutfits(rows, "MINIMALIST", 3);
+    expect(result).toEqual([]);
+  });
+
+  it("always builds outfits with the required top, bottom and footwear (never two tops)", () => {
+    const rows = buildCatalog(30);
+    const outfits = composeOutfits(rows, "SMART_CASUAL", 3);
+
+    expect(outfits.length).toBeGreaterThan(0);
+
+    for (const outfit of outfits) {
+      const categories = outfit.products.map((p) => p.category);
+      expect(categories).toContain("top");
+      expect(categories).toContain("bottom");
+      expect(categories).toContain("footwear");
+
+      const tops = categories.filter((c) => c === "top").length;
+      expect(tops).toBe(1);
+
+      const bottoms = categories.filter((c) => c === "bottom").length;
+      expect(bottoms).toBe(1);
+
+      const footwear = categories.filter((c) => c === "footwear").length;
+      expect(footwear).toBe(1);
+    }
+  });
+
+  it("respects a tight budget ceiling when preferences include one", () => {
+    const rows: RawRow[] = [];
+    for (let i = 0; i < 40; i++) {
+      const brand = CATALOG_BRANDS[i % CATALOG_BRANDS.length];
+      rows.push(
+        mkProduct(`top-${i}`, {
+          name: "Katoenen overhemd wit",
+          brand,
+          category: "top",
+          price: 40,
+          style: "smart-casual",
+        }),
+        mkProduct(`bottom-${i}`, {
+          name: "Slim fit chino beige",
+          brand,
+          category: "bottom",
+          price: 45,
+          style: "smart-casual",
+        }),
+        mkProduct(`footwear-${i}`, {
+          name: "Witte sneaker",
+          brand,
+          category: "footwear",
+          price: 50,
+          style: "casual",
+        }),
+      );
+    }
+
+    const maxBudget = 60;
+    const outfits = composeOutfits(rows, "SMART_CASUAL", 3, "male", {
+      budget: { min: 0, max: maxBudget },
+    });
+
+    expect(outfits.length).toBeGreaterThan(0);
+
+    const ceiling = maxBudget * 1.35;
+    for (const outfit of outfits) {
+      for (const product of outfit.products) {
+        expect(product.price).toBeLessThanOrEqual(ceiling);
+      }
+    }
+  });
+
+  it("produces different outfits when preferences change — scoring is not hardcoded", () => {
+    const rows = buildCatalog(40);
+
+    const casualOutfits = composeOutfits(rows, "SMART_CASUAL", 2, "male", {
+      goals: ["comfort"],
+      prints: "effen",
+      fit: "relaxed",
+    });
+    const trendyOutfits = composeOutfits(rows, "SMART_CASUAL", 2, "male", {
+      goals: ["trendy"],
+      prints: "statement",
+      fit: "slim",
+    });
+
+    expect(casualOutfits.length).toBeGreaterThan(0);
+    expect(trendyOutfits.length).toBeGreaterThan(0);
+
+    const casualIds = casualOutfits
+      .flatMap((o) => o.products.map((p) => p.id))
+      .sort();
+    const trendyIds = trendyOutfits
+      .flatMap((o) => o.products.map((p) => p.id))
+      .sort();
+
+    expect(casualIds).not.toEqual(trendyIds);
+  });
+
+  it("filters to the requested gender when enough gender-specific stock exists", () => {
+    const rows: RawRow[] = [];
+    for (let i = 0; i < 40; i++) {
+      rows.push(
+        mkProduct(`m-top-${i}`, {
+          category: "top",
+          gender: "male",
+          name: "Katoenen overhemd wit",
+        }),
+        mkProduct(`m-bottom-${i}`, {
+          category: "bottom",
+          gender: "male",
+          name: "Slim fit chino beige",
+        }),
+        mkProduct(`m-foot-${i}`, {
+          category: "footwear",
+          gender: "male",
+          name: "Witte sneaker",
+        }),
+        mkProduct(`f-top-${i}`, {
+          category: "top",
+          gender: "female",
+          name: "Zijden blouse",
+        }),
+      );
+    }
+
+    const outfits = composeOutfits(rows, "SMART_CASUAL", 3, "male");
+
+    expect(outfits.length).toBeGreaterThan(0);
+    for (const outfit of outfits) {
+      for (const product of outfit.products) {
+        expect(["male", "unisex"]).toContain(product.gender);
+      }
+    }
+  });
+
+  it("assigns a match score in a reasonable range (55-98)", () => {
+    const rows = buildCatalog(30);
+    const outfits = composeOutfits(rows, "MINIMALIST", 3);
+
+    expect(outfits.length).toBeGreaterThan(0);
+    for (const outfit of outfits) {
+      expect(outfit.matchScore).toBeGreaterThanOrEqual(55);
+      expect(outfit.matchScore).toBeLessThanOrEqual(98);
+    }
+  });
+
+  it("handles an empty preferences object without crashing", () => {
+    const rows = buildCatalog(30);
+    expect(() =>
+      composeOutfits(rows, "MINIMALIST", 3, undefined, {}),
+    ).not.toThrow();
+  });
+});

--- a/src/__tests__/engine/productFilter.test.ts
+++ b/src/__tests__/engine/productFilter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyCategory,
+  isAdultClothingProduct,
+} from "@/engine/productFilter";
+
+const adultBase = {
+  name: "Regular Fit Overhemd",
+  price: 59.95,
+  image_url: "https://example.com/shirt.jpg",
+};
+
+describe("isAdultClothingProduct", () => {
+  it("accepts a standard adult clothing item", () => {
+    expect(isAdultClothingProduct(adultBase)).toBe(true);
+  });
+
+  it("rejects items priced below the adult minimum", () => {
+    expect(
+      isAdultClothingProduct({ ...adultBase, price: 5.99 }),
+    ).toBe(false);
+  });
+
+  it("rejects items without an image", () => {
+    expect(
+      isAdultClothingProduct({
+        name: "Hoodie",
+        price: 40,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects children's clothing by name", () => {
+    expect(
+      isAdultClothingProduct({
+        ...adultBase,
+        name: "Jongens t-shirt wit",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects socks, underwear and other non-outfit items", () => {
+    const rejected = [
+      "Heren sokken 3-pack",
+      "Boxer shorts",
+      "Pyjama set",
+      "Badjas",
+    ];
+    for (const name of rejected) {
+      expect(
+        isAdultClothingProduct({ ...adultBase, name }),
+      ).toBe(false);
+    }
+  });
+
+  it("rejects items whose description mentions kids", () => {
+    expect(
+      isAdultClothingProduct({
+        ...adultBase,
+        description: "Perfect voor jongens in de lagere school",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("classifyCategory", () => {
+  it("classifies tops correctly", () => {
+    expect(classifyCategory({ name: "Katoenen overhemd wit" })).toBe("top");
+    expect(classifyCategory({ name: "Crewneck sweater navy" })).toBe("top");
+  });
+
+  it("classifies bottoms correctly", () => {
+    expect(classifyCategory({ name: "Slim fit chino beige" })).toBe("bottom");
+    expect(classifyCategory({ name: "Relaxed jeans donkerblauw" })).toBe(
+      "bottom",
+    );
+  });
+
+  it("classifies footwear correctly", () => {
+    expect(classifyCategory({ name: "Witte sneaker leer" })).toBe("footwear");
+    expect(classifyCategory({ name: "Chelsea boot zwart" })).toBe("footwear");
+  });
+
+  it("falls back to 'other' for unknown names without a db category", () => {
+    expect(classifyCategory({ name: "Iets mysterieus" })).toBe("other");
+  });
+
+  it("uses the database category as a fallback when name is ambiguous", () => {
+    expect(
+      classifyCategory({ name: "Mysterie item", category: "outerwear" }),
+    ).toBe("outerwear");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+const SRC_ALIAS = new URL("./src", import.meta.url).pathname;
+
+export default defineConfig({
+  resolve: {
+    alias: [{ find: "@", replacement: SRC_ALIAS }],
+  },
+  test: {
+    environment: "node",
+    include: ["src/__tests__/**/*.test.ts", "src/__tests__/**/*.test.tsx"],
+    exclude: ["node_modules", "dist", "e2e", ".netlify", "netlify"],
+    globals: false,
+    reporters: ["default"],
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
## Summary

- Restore the pieces needed to run typecheck and tests outside Bolt
  (`scripts/bolt-install.mjs` was stripping `@types/react`,
  `@types/react-dom`, and `vitest` in every environment) and add
  those packages back to `devDependencies`.
- Add a **vitest** suite for the recommendation engine: 27 unit tests
  across `productFilter`, `calculateMatchScore`, and `outfitComposer`.
  All tests pass.
- Add a **GitHub Actions** workflow that runs `npm ci`, `npm run
  typecheck`, `npm test`, and `npm run build` on push-to-main and PRs.
- Wire a `vitest run` step into the existing husky `pre-commit` hook so
  broken tests block commits locally.

## What the tests cover

The task brief referenced `src/engine/v2/` modules (`profileBuilder`,
`scorer`, `composer`), which don't exist in this branch — the engine
lives directly in `src/engine/`. The tests target the actual modules:

- **productFilter**: `isAdultClothingProduct` rejects kids' items,
  underwear/socks, and priced-below-threshold rows; `classifyCategory`
  maps names to top/bottom/footwear/other and falls back to the DB
  category.
- **calculateMatchScore**: preference-driven score sums correctly and
  is *not* hardcoded (flipping preferences changes the score);
  `calculateMatchPercentage` clamps to 0-100 and guards division by zero.
- **outfitComposer**: every outfit has exactly one top, bottom, and
  footwear (never two tops); empty catalogs and missing categories
  return `[]`; budget preferences cap per-item price; gender filter
  respects male/unisex; different preferences produce different
  outfits; match scores land in the documented 55-98 range.

## ⚠️ Important notes

### Typecheck is informational (for now)
The codebase carries **~660 pre-existing TypeScript errors across ~160
files** — unrelated to this PR's changes. They are legitimate bugs
(`supabase is possibly null`, property mismatches, missing modules)
but fall outside the scope of setting up CI. The workflow runs
`npm run typecheck` with `continue-on-error: true` so PRs aren't
blocked until that backlog is worked down. Once clean, drop
`continue-on-error` to make typecheck a hard gate.

### Workflow file location
`.github/workflows/ci.yml` could not be pushed: the OAuth token used
to create this PR does not have the `workflow` scope. The workflow is
checked in at **`.github/workflows-proposed/ci.yml`** with a README
explaining how to activate it — a one-line `git mv` via the GitHub
web UI (or a token with the `workflow` scope) is enough.

### Pre-commit hook
Husky was already configured. The existing `pre-commit` is extended
to run `vitest run --reporter=dot` before `lint-staged`. Full
`tsc --noEmit` was intentionally *not* added to pre-commit — with
660+ pre-existing errors it would block every commit until they are
fixed. Vitest is the pragmatic gate until then.

## Test plan
- [x] `npm install` succeeds outside Bolt with `@types/react`,
      `@types/react-dom`, and `vitest` present in `node_modules/`
- [x] `npm test` → 27/27 passing
- [x] `npm run build` → succeeds
- [x] `npm run typecheck` → runs (still reports pre-existing errors)
- [ ] After merge: move `.github/workflows-proposed/ci.yml` →
      `.github/workflows/ci.yml` and verify the first CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)