### PR TITLE
feat(engine): wire results page to engine v2 with moodboard support

### DIFF
--- a/src/engine/generateOutfits.ts
+++ b/src/engine/generateOutfits.ts
@@ -1,4 +1,9 @@
 import { Product, Outfit, Season, ProductCategory, OutfitGenerationOptions, Weather, CategoryRatio, VariationLevel } from './types';
+
+// Set true only for local debugging — never in production builds
+const _debug = false;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const _log = _debug ? console.log.bind(console) : (..._args: any[]) => {};
 import { generateOutfitTitle, generateOutfitDescription } from './generateOutfitDescriptions';
 import { generateOutfitExplanation } from './explainOutfit';
 import { filterProductsByColorSeason } from './colorSeasonFiltering';
@@ -264,20 +269,20 @@ function generateOutfits(
   const budgetPref = options?.budget;
   
   // Log archetype information
-  console.log("Generating outfits with archetypes:", 
+  _log("Generating outfits with archetypes:", 
     secondaryArchetype 
       ? `${primaryArchetype} (${Math.round((1-mixFactor)*100)}%) + ${secondaryArchetype} (${Math.round(mixFactor*100)}%)`
       : primaryArchetype
   );
-  console.log("Variation level:", variationLevel);
-  console.log("Enforce completion:", enforceCompletion);
-  console.log("Min completeness:", minCompleteness);
+  _log("Variation level:", variationLevel);
+  _log("Enforce completion:", enforceCompletion);
+  _log("Min completeness:", minCompleteness);
 
   // If secondary archetype is the same as primary or undefined, ignore it
   if (!secondaryArchetype || secondaryArchetype === primaryArchetype) {
     secondaryArchetype = undefined;
     mixFactor = 0;
-    console.log("Using 100% primary archetype:", primaryArchetype);
+    _log("Using 100% primary archetype:", primaryArchetype);
   }
 
   // Get current season or use preferred season if specified
@@ -285,17 +290,17 @@ function generateOutfits(
     ? preferredSeasons[0] 
     : getCurrentSeason()) as Season;
   
-  console.log("Active season:", currentSeason);
+  _log("Active season:", currentSeason);
   
   // Determine weather if not specified
   const activeWeather = weather ?? getTypicalWeatherForSeason(currentSeason);
-  console.log("Active weather:", activeWeather);
+  _log("Active weather:", activeWeather);
   
   // Filter products by season
   const seasonalProducts = products.filter(product => 
     !product.season || product.season.includes(currentSeason)
   );
-  console.log("Products suitable for season:", seasonalProducts.length);
+  _log("Products suitable for season:", seasonalProducts.length);
   
   // Further filter by weather if specified
   let weatherFilteredProducts = seasonalProducts;
@@ -303,7 +308,7 @@ function generateOutfits(
     weatherFilteredProducts = seasonalProducts.filter(product => 
       isProductSuitableForWeather(product, weather)
     );
-    console.log("Products suitable for weather:", weatherFilteredProducts.length);
+    _log("Products suitable for weather:", weatherFilteredProducts.length);
   }
   
   const basePoolBeforeColor = weatherFilteredProducts.length >= 4
@@ -323,7 +328,7 @@ function generateOutfits(
     const colorFiltered = filterProductsByColorSeason(basePoolBeforeColor, colorProfile, false);
     if (colorFiltered.length >= 4) {
       colorFilteredProducts = colorFiltered;
-      console.log(`[colorSeason] Filtered to ${colorFiltered.length} color-compatible products`);
+      _log(`[colorSeason] Filtered to ${colorFiltered.length} color-compatible products`);
     } else {
       console.warn(`[colorSeason] Too few color-compatible products (${colorFiltered.length}), using full pool`);
     }
@@ -345,7 +350,7 @@ function generateOutfits(
     });
     if (effeFiltered.length >= 4) {
       productsToUse = effeFiltered;
-      console.log(`[prints] Hard-filtered to ${effeFiltered.length} plain products`);
+      _log(`[prints] Hard-filtered to ${effeFiltered.length} plain products`);
     }
   } else if (printsPreference === 'statement') {
     // For statement preference, give printed products priority by moving them to the front
@@ -356,7 +361,7 @@ function generateOutfits(
       return (bHasPrint ? 1 : 0) - (aHasPrint ? 1 : 0);
     });
     productsToUse = printedFirst;
-    console.log(`[prints] Prioritised statement prints`);
+    _log(`[prints] Prioritised statement prints`);
   }
 
   // Materials: soft boost — sort preferred materials to the top of each category pool
@@ -371,7 +376,7 @@ function generateOutfits(
       };
       return getMatScore(b) - getMatScore(a);
     });
-    console.log(`[materials] Re-sorted pool to prefer: ${normPrefs.join(', ')}`);
+    _log(`[materials] Re-sorted pool to prefer: ${normPrefs.join(', ')}`);
   }
 
   // Define occasions based on archetype and preferred occasions
@@ -391,7 +396,7 @@ function generateOutfits(
         ...occasions.filter(occ => !validPreferredOccasions.includes(occ))
       ];
       
-      console.log("Using preferred occasions:", validPreferredOccasions);
+      _log("Using preferred occasions:", validPreferredOccasions);
     }
   }
   
@@ -454,8 +459,8 @@ function generateOutfits(
   }
 
   // Log generation attempts
-  console.log("Outfit generation attempts:", attemptsPerOccasion);
-  console.log("Generated outfits:", outfits.length);
+  _log("Outfit generation attempts:", attemptsPerOccasion);
+  _log("Generated outfits:", outfits.length);
 
   return outfits;
 }
@@ -509,9 +514,9 @@ function generateOutfitForOccasion(
   budgetPref?: { min: number; max: number },
 ): Outfit | null {
   // Log outfit generation
-  console.log("Outfit op basis van:", primaryArchetype, secondaryArchetype ? "+" : "", secondaryArchetype || "");
-  console.log("Season:", season, "Weather:", weather);
-  console.log("Variation level:", variationLevel);
+  _log("Outfit op basis van:", primaryArchetype, secondaryArchetype ? "+" : "", secondaryArchetype || "");
+  _log("Season:", season, "Weather:", weather);
+  _log("Variation level:", variationLevel);
 
   // Get variation settings
   const variation = variationSettings[variationLevel];
@@ -520,7 +525,7 @@ function generateOutfitForOccasion(
   const productsByCategory = groupProductsByCategory(products);
   
   // Log available categories and counts
-  console.log("Beschikbare productcategorieën:", 
+  _log("Beschikbare productcategorieën:", 
     Object.entries(productsByCategory)
       .map(([category, prods]) => `${category}: ${prods.length}`)
       .join(', ')
@@ -555,7 +560,7 @@ function generateOutfitForOccasion(
     });
   }
   
-  console.log(`Using outfit structure for ${primaryArchetype} in ${season}:`, 
+  _log(`Using outfit structure for ${primaryArchetype} in ${season}:`, 
     `Required: [${outfitStructure.requiredCategories.join(', ')}], ` +
     `Optional: [${outfitStructure.optionalCategories.join(', ')}]`
   );
@@ -651,7 +656,7 @@ function generateOutfitForOccasion(
               if (idx !== -1) outfitStructure.requiredCategories.splice(idx, 1);
             });
 
-            console.log(`Used ${substituteCategory} as substitute for ${category}`);
+            _log(`Used ${substituteCategory} as substitute for ${category}`);
             break;
           }
         }
@@ -723,7 +728,7 @@ function generateOutfitForOccasion(
     // If we have fallback products and we're not enforcing completion, add them
     // NOTE: fallback products are only added if they are valid wearable items
     if (fallbackProducts.length > 0 && !enforceCompletion) {
-      console.log(`Adding ${fallbackProducts.length} fallback products to complete the outfit`);
+      _log(`Adding ${fallbackProducts.length} fallback products to complete the outfit`);
 
       for (const fallbackProduct of fallbackProducts) {
         if (outfitProducts.length >= outfitStructure.minItems) break;
@@ -833,10 +838,10 @@ function generateOutfitForOccasion(
   const categoryRatio = calculateCategoryRatio(outfitProducts);
   
   // Log the final outfit composition
-  console.log("Outfit samengesteld met types:", outfitProducts.map(p => p.type || p.category));
-  console.log("Outfit structure categories:", selectedCategories);
-  console.log("Outfit completeness:", completeness + "%");
-  console.log("Outfit category ratio:", categoryRatio);
+  _log("Outfit samengesteld met types:", outfitProducts.map(p => p.type || p.category));
+  _log("Outfit structure categories:", selectedCategories);
+  _log("Outfit completeness:", completeness + "%");
+  _log("Outfit category ratio:", categoryRatio);
   
   const primaryKey = resolveArchetypeKey(primaryArchetype);
   const outfitMix: ArchetypeWeights = { [primaryKey]: 1 - (mixFactor ?? 0) };
@@ -1327,7 +1332,7 @@ function selectProductForCategory(
   const picked = weightedRandomPick(scoredProducts);
 
   if (picked) {
-    console.log(`[Select] ${category} → "${picked.product.name}" score=${picked.combined.toFixed(2)} fusion=${picked.fusionScore.toFixed(2)}`);
+    _log(`[Select] ${category} → "${picked.product.name}" score=${picked.combined.toFixed(2)} fusion=${picked.fusionScore.toFixed(2)}`);
   }
 
   return picked?.product ?? null;

--- a/src/engine/outfitComposer.ts
+++ b/src/engine/outfitComposer.ts
@@ -135,6 +135,7 @@ const ARCHETYPE_OCCASIONS: Record<string, string[]> = {
   STREETWEAR:   ['weekend', 'casual', 'relaxed', 'avond', 'date'],
   ATHLETIC:     ['sport', 'casual', 'weekend', 'relaxed'],
   AVANT_GARDE:  ['avond', 'date', 'casual', 'weekend', 'smart'],
+  BUSINESS:     ['werk', 'smart', 'avond', 'date', 'casual'],
 };
 
 const FORMALITY_KEYWORDS: Record<string, RegExp[]> = {

--- a/src/engine/productClassifier.ts
+++ b/src/engine/productClassifier.ts
@@ -136,6 +136,7 @@ const OUTERWEAR_RULES: PatternEntry[] = [
   { regex: /\bpeacoat\b|\bpea[\s-]?coat\b/i, subcategory: 'peacoat', weight: 3 },
   { regex: /\bboucl[eé]?[\s-]?jas\b|\bboucle[\s-]?coat\b/i, subcategory: 'boucle jas', weight: 3 },
   { regex: /\bovershirt\b/i, subcategory: 'overshirt', weight: 3 },
+  { regex: /\bkostuum\b/i, subcategory: 'kostuum', weight: 3 },
   { regex: /\bblazer\b/i, subcategory: 'blazer', weight: 2 },
   { regex: /\bcolbert\b/i, subcategory: 'colbert', weight: 2 },
   { regex: /\bponcho\b|\bcape\b/i, subcategory: 'cape', weight: 2 },

--- a/src/hooks/useOutfits.ts
+++ b/src/hooks/useOutfits.ts
@@ -1,6 +1,7 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { getFeed } from '@/services/DataRouter';
 import { fetchOutfits } from '@/services/data/dataService';
+import { outfitService } from '@/services/outfits/outfitService';
 import type { Outfit } from '@/services/data/types';
 
 interface UseOutfitsOptions {
@@ -18,6 +19,8 @@ interface UseOutfitsOptions {
   colorProfile?: any;
   occasions?: string[];
   budget?: { min: number; max: number };
+  /** When provided, engine v2 is used via outfitService (moodboard-aware). */
+  answers?: Record<string, any>;
 }
 
 interface UseOutfitsResult {
@@ -49,11 +52,13 @@ export function useOutfits(options: UseOutfitsOptions = {}): UseOutfitsResult {
     colorProfile,
     occasions,
     budget,
+    answers,
   } = options;
 
   // Stable query key based on all parameters that affect results
   const queryKey = [
     'outfits',
+    answers ? 'v2' : 'v1',
     archetype ?? '',
     secondaryArchetype ?? '',
     mixFactor ?? 0,
@@ -72,6 +77,18 @@ export function useOutfits(options: UseOutfitsOptions = {}): UseOutfitsResult {
   const query = useQuery({
     queryKey,
     queryFn: async () => {
+      // Engine v2 path: use outfitService which reads moodboard data from localStorage
+      if (answers) {
+        const generated = await outfitService.generateOutfits(answers, limit ?? 9);
+        return {
+          data: generated as any as Outfit[],
+          source: 'supabase' as const,
+          cached: false,
+          errors: [] as string[],
+        };
+      }
+
+      // Legacy path: dataService → outfitComposer (v1)
       const response = await fetchOutfits({
         archetype,
         secondaryArchetype,

--- a/src/lib/quiz/seeds.ts
+++ b/src/lib/quiz/seeds.ts
@@ -71,30 +71,45 @@ const SEED_OUTFITS: Record<string, Omit<OutfitSeed, "id">[]> = {
     { title: "Gallery Look", vibe: "Smart", notes: "Clean maar onconventioneel; een statement piece." },
     { title: "Night Creative", vibe: "Avond", notes: "Donkere basis met tactiele textuur." },
   ],
+  BUSINESS: [
+    { title: "Tailored Werk", vibe: "Kantoor", notes: "Strak colbert met nette pantalon; oxford schoenen." },
+    { title: "Smart Presentatie", vibe: "Meeting", notes: "Blazer met crisp overhemd; gepolijste loafers." },
+    { title: "Business Casual", vibe: "Kantoor casual", notes: "Chino met button-down; clean loafers of derby." },
+    { title: "Zakelijk Dinner", vibe: "Diner", notes: "Donker kostuum of smart blazer; verfijnde accessoires." },
+    { title: "Travel Professional", vibe: "Zakenreis", notes: "Kreukvrije pantalon met overhemd; derby schoenen." },
+    { title: "Power Casual", vibe: "Vrije dag", notes: "Smart chino met luxe knitwear; nette schoen." },
+  ],
 };
 
 function seasonText(c: ColorProfile): { palette: string; accentTip: string } {
   switch (c.season) {
-    case "lente":  return { palette: "licht-warme neutrals", accentTip: "lichte, warme accenten" };
-    case "zomer":  return { palette: "zacht-koele tonals", accentTip: "koele, zachte accenten" };
-    case "herfst": return { palette: "aards-warme neutrals", accentTip: "diepere, warme accenten" };
+    case "lente":
+    case "spring": return { palette: "licht-warme neutrals", accentTip: "lichte, warme accenten" };
+    case "zomer":
+    case "summer": return { palette: "zacht-koele tonals", accentTip: "koele, zachte accenten" };
+    case "herfst":
+    case "autumn": return { palette: "aards-warme neutrals", accentTip: "diepere, warme accenten" };
     case "winter": return { palette: "crispe koele neutrals", accentTip: "hoog contrast, koel accent" };
+    default:       return { palette: "neutrale tinten", accentTip: "zachte kleuraccenten" };
   }
 }
 
 function getSeasonalColors(c: ColorProfile): { base: string[]; accent: string[] } {
   switch (c.season) {
     case "lente":
+    case "spring":
       return {
         base: ["#E8DDD3", "#D4C4B0", "#F5F0E8", "#C9B8A0"],
         accent: ["#E8B4A0", "#D4A88C", "#F0C8B0"],
       };
     case "zomer":
+    case "summer":
       return {
         base: ["#E0E8F0", "#D0D8E0", "#C8D4DC", "#B8C8D4"],
         accent: ["#A8C4D8", "#98B8CC", "#B0D0E0"],
       };
     case "herfst":
+    case "autumn":
       return {
         base: ["#C8B8A0", "#B0A090", "#A89080", "#988070"],
         accent: ["#D4A080", "#C49070", "#B88860"],
@@ -103,6 +118,11 @@ function getSeasonalColors(c: ColorProfile): { base: string[]; accent: string[] 
       return {
         base: ["#F0F0F0", "#E0E0E0", "#D0D0D0", "#303030"],
         accent: ["#E0F0F8", "#D0E8F0", "#C0E0E8"],
+      };
+    default:
+      return {
+        base: ["#E8E0D8", "#D8D0C8", "#F0EBE4", "#C8C0B8"],
+        accent: ["#D4A88C", "#C8A080", "#E0B898"],
       };
   }
 }

--- a/src/pages/EnhancedResultsPage.tsx
+++ b/src/pages/EnhancedResultsPage.tsx
@@ -382,6 +382,7 @@ export default function EnhancedResultsPage() {
     colorProfile: activeColorProfile,
     occasions: answers?.occasions,
     budget: parsedBudget,
+    answers: answers ?? undefined,
   });
 
   const seeds: OutfitSeed[] = React.useMemo(() => {

--- a/src/services/outfits/outfitService.ts
+++ b/src/services/outfits/outfitService.ts
@@ -116,7 +116,10 @@ class OutfitService {
 
       const outfitsWithExplanations = outfits.map((outfit) => ({
         ...outfit,
-        explanation: this.generateExplanation(outfit, quizAnswers),
+        // Preserve engine v2 explanations; only apply fallback template when empty
+        explanation: outfit.explanation?.trim()
+          ? outfit.explanation
+          : this.generateExplanation(outfit, quizAnswers),
       }));
 
       console.log(`[OutfitService] Successfully generated ${outfitsWithExplanations.length} outfits`);


### PR DESCRIPTION
## Summary

- **Engine v2 in results page**: `useOutfits` now routes through `outfitService.generateOutfits` when quiz answers are provided, activating engine v2's 11-dimensional scoring and automatic moodboard swipe data pickup (`ff_visual_embedding`, `ff_swipe_count`, `ff_swipe_pattern`). Legacy `fetchOutfits` path retained as fallback when answers are absent.
- **Explanation fix**: `outfitService` no longer overwrites engine v2 explanations with the generic "Deze outfit past perfect bij jouw X stijl." template — original v2 explanation is preserved and fallback only applies when empty.
- **Classifier fix**: `kostuum` added to `OUTERWEAR_RULES` (weight 3) so business suits are properly classified instead of falling through to `OTHER` and being silently rejected.
- **BUSINESS archetype fix**: `BUSINESS` added to `ARCHETYPE_OCCASIONS` in `outfitComposer.ts` (was completely missing, causing empty outfit lists for BUSINESS users using the legacy path).
- **Console log cleanup**: All 28 debug `console.log` calls in `generateOutfits.ts` (v1 engine) demoted behind a `_debug = false` flag — `console.warn` for real errors preserved.
- **Seed outfits**: BUSINESS archetype seed outfits added (6 looks); `seasonText`/`getSeasonalColors` now handle English season keys (`spring`, `summer`, `autumn`) and include a `default` case to prevent silent `undefined` crashes.

## Test plan

- [ ] Complete style quiz → navigate to results → verify outfits load (not empty)
- [ ] Open browser console → confirm no debug log spam from `generateOutfits.ts`
- [ ] Set archetype to BUSINESS → verify outfits appear (seed fallback and live)
- [ ] Check outfit explanation is personalized (not generic template) when engine v2 is active
- [ ] Verify build stays green: `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)