### PR TITLE
fix(results): stop outfit refetch loop on results page

### DIFF
--- a/src/hooks/useOutfits.ts
+++ b/src/hooks/useOutfits.ts
@@ -4,6 +4,22 @@ import { fetchOutfits } from '@/services/data/dataService';
 import { outfitService } from '@/services/outfits/outfitService';
 import type { Outfit } from '@/services/data/types';
 
+/**
+ * Deterministic string digest of a quiz-answers object, used as part of the
+ * React Query key. Stable JSON ordering ensures two calls with the same answer
+ * content produce the same key regardless of object reference or key order.
+ */
+function stableAnswersKey(answers: Record<string, any>): string {
+  try {
+    const keys = Object.keys(answers).sort();
+    const normalized: Record<string, any> = {};
+    for (const k of keys) normalized[k] = answers[k];
+    return JSON.stringify(normalized);
+  } catch {
+    return '';
+  }
+}
+
 interface UseOutfitsOptions {
   archetype?: string;
   secondaryArchetype?: string;
@@ -55,27 +71,37 @@ export function useOutfits(options: UseOutfitsOptions = {}): UseOutfitsResult {
     answers,
   } = options;
 
-  // Stable query key based on all parameters that affect results
-  const queryKey = [
-    'outfits',
-    answers ? 'v2' : 'v1',
-    archetype ?? '',
-    secondaryArchetype ?? '',
-    mixFactor ?? 0,
-    season ?? '',
-    limit ?? 9,
-    gender ?? '',
-    fit ?? '',
-    prints ?? '',
-    (goals || []).sort().join(','),
-    (materials || []).sort().join(','),
-    (occasions || []).sort().join(','),
-    budget?.min ?? '',
-    budget?.max ?? '',
-  ];
+  // Engine v2 reads moodboard/archetype/color from answers + localStorage itself,
+  // so the queryKey only needs a stable digest of answers + limit. Including
+  // archetype/secondaryArchetype/mixFactor/colorProfile here would cause
+  // unnecessary refetches when those resolve asynchronously on the results page.
+  const queryKey = answers
+    ? ([
+        'outfits',
+        'v2',
+        stableAnswersKey(answers),
+        limit ?? 9,
+      ] as const)
+    : ([
+        'outfits',
+        'v1',
+        archetype ?? '',
+        secondaryArchetype ?? '',
+        mixFactor ?? 0,
+        season ?? '',
+        limit ?? 9,
+        gender ?? '',
+        fit ?? '',
+        prints ?? '',
+        (goals || []).slice().sort().join(','),
+        (materials || []).slice().sort().join(','),
+        (occasions || []).slice().sort().join(','),
+        budget?.min ?? '',
+        budget?.max ?? '',
+      ] as const);
 
   const query = useQuery({
-    queryKey,
+    queryKey: queryKey as unknown as readonly unknown[],
     queryFn: async () => {
       // Engine v2 path: use outfitService which reads moodboard data from localStorage
       if (answers) {
@@ -113,8 +139,14 @@ export function useOutfits(options: UseOutfitsOptions = {}): UseOutfitsResult {
       };
     },
     enabled,
-    staleTime: 1000 * 60 * 10, // 10 min — outfits don't change often
-    gcTime: 1000 * 60 * 30,    // Keep in cache 30 min after unmount
+    // Outfits are deterministic per quiz answer set. Keep the result pinned for
+    // the lifetime of the session so async updates (archetype detection, color
+    // profile generation) don't trigger refetches.
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 30,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 
   const result = query.data;

--- a/src/pages/EnhancedResultsPage.tsx
+++ b/src/pages/EnhancedResultsPage.tsx
@@ -217,9 +217,13 @@ export default function EnhancedResultsPage() {
     });
   }, []);
 
-  const color = readJson<ColorProfile>(LS_KEYS.COLOR_PROFILE);
-  const archetypeRaw = readJson<Archetype>(LS_KEYS.ARCHETYPE);
-  const answers = readJson<any>(LS_KEYS.QUIZ_ANSWERS);
+  // Read localStorage snapshots once per mount so that every render downstream
+  // gets a stable reference. Without this, `readJson` returns a fresh object on
+  // every render, which causes effects that depend on `answers` (and
+  // `useOutfits` in v1 mode) to thrash.
+  const color = React.useMemo(() => readJson<ColorProfile>(LS_KEYS.COLOR_PROFILE), []);
+  const archetypeRaw = React.useMemo(() => readJson<Archetype>(LS_KEYS.ARCHETYPE), []);
+  const answers = React.useMemo(() => readJson<any>(LS_KEYS.QUIZ_ANSWERS), []);
 
   const hasCompletedQuiz = !!answers;
 


### PR DESCRIPTION
## Summary
- Engine v2 path in `useOutfits` no longer includes v1-only options (`secondaryArchetype`, `mixFactor`, `colorProfile`, etc.) in its React Query key, so async-resolving archetype detection and color-profile generation on the results page no longer invalidate the cache and retrigger fetches.
- Outfit queries now pin with `staleTime: Infinity` and `refetchOn{Mount,WindowFocus,Reconnect}: false` — outfits are deterministic per quiz answer set, so background refetches are never useful.
- `EnhancedResultsPage` memoizes its `readJson` localStorage snapshots (`answers`, `color`, `archetypeRaw`) so every downstream hook and effect gets a stable reference instead of a fresh object per render.

## Why it refreshed
1. `secondaryArchetype` + `mixFactor` flipped from `undefined/0` → real values once `ArchetypeDetector.detect` resolved, changing the queryKey.
2. `generatedProfile` / `activeColorProfile` settled after `StyleProfileGenerator.generateStyleProfile`, causing another render and (previously) re-evaluation.
3. `readJson` returned a new object reference every render, so `[answers]`-dependent effects (e.g. `consistencyAnalysis`) kept firing.

Engine v2 reads archetype/color/moodboard from `answers` + localStorage, so none of the invalidating keys were actually needed in the queryKey.

## Test plan
- [ ] Complete the quiz and land on `/results` — verify outfits render once and stop (no visible flicker, no network refetch loop).
- [ ] Open React Query devtools or the Network tab and confirm a single `generateOutfits` run per session.
- [ ] Archetype breakdown + color profile sections still populate after async detection completes (no regression in content).
- [ ] v1 path (flag engine v2 off via `ff_engine_v2=0`) still honors the full queryKey and reacts to archetype/color changes as before.
- [ ] `npm run build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)