### PR TITLE
fix(engine/v2): enforce outfit completeness and activate budget guardrails

### DIFF
--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -191,23 +191,34 @@ function pickTopArchetypes(weights: ArchetypeWeights): {
 function parseBudget(answers: Record<string, any>): {
   perItemMax: number;
   perItemMin: number;
+  totalMax: number;
 } {
   const explicit =
     answers.budget && typeof answers.budget === 'object'
       ? answers.budget
       : null;
   if (explicit && typeof explicit.max === 'number') {
+    const perItemMax = Math.max(15, explicit.max);
+    const perItemMin =
+      typeof explicit.min === 'number'
+        ? Math.max(0, explicit.min)
+        : perItemMax * 0.3;
     return {
-      perItemMax: Math.max(15, explicit.max),
-      perItemMin: typeof explicit.min === 'number' ? Math.max(0, explicit.min) : 0,
+      perItemMax,
+      perItemMin,
+      totalMax: perItemMax * 4,
     };
   }
   const slider =
     typeof answers.budgetRange === 'number' ? answers.budgetRange : null;
   if (slider !== null && slider > 0) {
-    return { perItemMax: slider, perItemMin: 0 };
+    return {
+      perItemMax: slider,
+      perItemMin: slider * 0.3,
+      totalMax: slider * 4,
+    };
   }
-  return { perItemMax: 150, perItemMin: 0 };
+  return { perItemMax: 150, perItemMin: 45, totalMax: 600 };
 }
 
 function normalizeOccasions(raw: any): OccasionKey[] {

--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -155,7 +155,14 @@ function tryCompose(
 ): ScoredProduct[] | null {
   const items: ScoredProduct[] = [];
   const seenIds = new Set<string>();
-  const push = (p?: ScoredProduct) => {
+  const pushRequired = (p?: ScoredProduct) => {
+    if (!p) return false;
+    if (seenIds.has(p.product.id)) return false;
+    seenIds.add(p.product.id);
+    items.push(p);
+    return true;
+  };
+  const pushOptional = (p?: ScoredProduct) => {
     if (!p) return true;
     if (seenIds.has(p.product.id)) return false;
     seenIds.add(p.product.id);
@@ -164,14 +171,14 @@ function tryCompose(
   };
 
   if (picks.dress) {
-    if (!push(picks.dress)) return null;
+    if (!pushRequired(picks.dress)) return null;
   } else {
-    if (!push(picks.top)) return null;
-    if (!push(picks.bottom)) return null;
+    if (!pushRequired(picks.top)) return null;
+    if (!pushRequired(picks.bottom)) return null;
   }
-  if (!push(picks.footwear)) return null;
-  if (!push(picks.outerwear)) return null;
-  if (!push(picks.accessory)) return null;
+  if (!pushRequired(picks.footwear)) return null;
+  if (!pushOptional(picks.outerwear)) return null;
+  if (!pushOptional(picks.accessory)) return null;
 
   if (isHardMismatch(items)) return null;
   if (!withinTotalBudget(items, profile)) return null;


### PR DESCRIPTION
## Summary

Three P0 fixes in engine v2 composition caught by testrapport:

- **Budget `totalMax` was dead code.** `parseBudget` never set it, so `withinTotalBudget` in `composer.ts` always returned `true`. Now derived as `perItemMax * 4`.
- **Outfits without a bottom slipped through.** The `push` helper in `tryCompose` returned `true` for `undefined` items, so a top + footwear combo (no bottom) passed the length check. Split into `pushRequired` / `pushOptional` and hard-require top + bottom + footwear (or dress + footwear).
- **`perItemMin` defaulted to 0.** A €12 H&M top scored 1.0 for a user with €150 budget. Now defaults to 30% of `perItemMax` when no min is provided.

## Files touched

- `src/engine/v2/buildProfile.ts` — `parseBudget` now always returns `totalMax` and a sensible `perItemMin`.
- `src/engine/v2/composer.ts` — `tryCompose` splits required vs optional slots so missing top/bottom/footwear actually fail.

## Test plan

- [x] `npm run build` passes
- [ ] Verify quiz with €150 slider no longer returns H&M-cheap-only outfits
- [ ] Verify outfit grid never shows a 2-product card that is top+footwear
- [ ] Verify total-budget filter kicks in when the composer price sum exceeds `perItemMax * 4 * 1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)