### PR TITLE
feat(engine): expand quiz style options for full archetype coverage

### DIFF
--- a/src/data/quizSteps.ts
+++ b/src/data/quizSteps.ts
@@ -18,6 +18,11 @@ export const getStyleOptionsForGender = (gender?: string) => {
         : 'Tijdloze elegantie, verfijnde stukken'
     },
     {
+      value: 'business',
+      label: 'Zakelijk / Business',
+      description: 'Pakken, blazers en nette kleding voor kantoor en formele momenten'
+    },
+    {
       value: 'streetwear',
       label: 'Urban/Streetwear',
       description: isMale
@@ -27,6 +32,16 @@ export const getStyleOptionsForGender = (gender?: string) => {
   ];
 
   const femaleOptions = [
+    {
+      value: 'smart-casual',
+      label: 'Smart Casual',
+      description: 'Verzorgd en relaxed: blazers, nette broeken, loafers'
+    },
+    {
+      value: 'casual',
+      label: 'Casual / Alledaags',
+      description: 'Comfortabele, ontspannen stijl voor dagelijks gebruik'
+    },
     {
       value: 'bohemian',
       label: 'Bohemien',
@@ -59,6 +74,16 @@ export const getStyleOptionsForGender = (gender?: string) => {
       value: 'rugged',
       label: 'Stoer/Rugged',
       description: 'Robuuste materialen, outdoor-geïnspireerd, mannelijk'
+    },
+    {
+      value: 'edgy',
+      label: 'Stoer (Edgy)',
+      description: 'Rock-geïnspireerd met leer, denim en statement-stukken'
+    },
+    {
+      value: 'avant-garde',
+      label: 'Experimenteel / Avant-garde',
+      description: 'Oversized silhouetten, donker palet, designer-merken'
     }
   ];
 

--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -26,6 +26,8 @@ const QUIZ_STYLE_TO_ARCHETYPE: Record<string, ArchetypeWeights> = {
   bohemian: { AVANT_GARDE: 0.4, SMART_CASUAL: 0.6 },
   romantic: { CLASSIC: 0.6, SMART_CASUAL: 0.4 },
   edgy: { STREETWEAR: 0.5, AVANT_GARDE: 0.5 },
+  'avant-garde': { AVANT_GARDE: 1.0 },
+  avant_garde: { AVANT_GARDE: 1.0 },
   androgynous: { MINIMALIST: 0.7, SMART_CASUAL: 0.3 },
   luxury: { CLASSIC: 0.5, BUSINESS: 0.3, AVANT_GARDE: 0.2 },
   casual: { SMART_CASUAL: 0.7, STREETWEAR: 0.3 },


### PR DESCRIPTION
## Summary
- Adds missing style options so all engine v2 archetypes are reachable via the quiz
- Women can now select `business` (shared), `smart-casual` and `casual`; men can now select `avant-garde` and `edgy`
- Adds `avant-garde` / `avant_garde` mapping to `QUIZ_STYLE_TO_ARCHETYPE` in `buildProfile.ts` so the new male option resolves to the `AVANT_GARDE` archetype

## Background
Engine v2 test reports surfaced that a subset of archetypes (BUSINESS, AVANT_GARDE) could not be reached through the quiz because the relevant style options were missing for one or both genders. This PR only touches the option lists and one mapping — no changes to scoring, calibration, or the occasion list (all six existing occasions already have matching `OCCASION_ARCHETYPE_BIAS` entries).

## Changes
- `src/data/quizSteps.ts`
  - `sharedOptions`: + `business` ("Zakelijk / Business")
  - `femaleOptions`: + `smart-casual`, + `casual`
  - `maleOptions`: + `edgy`, + `avant-garde` ("Experimenteel / Avant-garde")
- `src/engine/v2/buildProfile.ts`
  - `QUIZ_STYLE_TO_ARCHETYPE`: + `'avant-garde': { AVANT_GARDE: 1.0 }` and `avant_garde` alias

## Test plan
- [x] `npm run build` succeeds
- [ ] Start quiz as female — verify the new `business`, `smart-casual`, `casual` options appear and can be selected
- [ ] Start quiz as male — verify the new `edgy` and `avant-garde` options appear and can be selected
- [ ] Complete the quiz selecting `avant-garde` only and confirm `primaryArchetype === 'AVANT_GARDE'` in the resulting profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)