### PR TITLE
fix(engine): kalibreer v2 scoring zodat matchpercentage eerlijk is

### DIFF
--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -81,8 +81,8 @@ function buildExplanation(
 
 function buildMatchPercentage(candidate: OutfitCandidate): number {
   const raw = candidate.compositionScore;
-  const scaled = 58 + raw * 40;
-  return Math.round(Math.max(55, Math.min(98, scaled)));
+  const scaled = 30 + raw * 65;
+  return Math.round(Math.max(30, Math.min(98, scaled)));
 }
 
 function categoryRatio(candidate: OutfitCandidate): {

--- a/src/engine/v2/scoring/archetype.ts
+++ b/src/engine/v2/scoring/archetype.ts
@@ -10,7 +10,7 @@ function tokenScore(tokens: string[] | undefined, needles: string[]): number {
   for (const t of tokens) {
     if (needleSet.has(t.toLowerCase())) hits++;
   }
-  return Math.min(1, hits / Math.min(3, needles.length));
+  return Math.min(1, hits / Math.min(2, needles.length));
 }
 
 function formalityProximity(

--- a/src/engine/v2/scoring/index.ts
+++ b/src/engine/v2/scoring/index.ts
@@ -79,7 +79,8 @@ export function computeProductScore(
     weights.prints * breakdown.prints +
     weights.quality * breakdown.quality;
 
-  const archetypePenalty = archetype.score < 0.2 ? 0.9 : 1;
+  const archetypePenalty =
+    archetype.score < 0.2 ? 0.6 : archetype.score < 0.35 ? 0.85 : 1;
   const occasionPenalty = occasionRes.score < 0.2 ? 0.85 : 1;
   const budgetPenalty = budget.score < 0.2 ? 0.8 : 1;
   const multiplier = archetypePenalty * occasionPenalty * budgetPenalty;


### PR DESCRIPTION
## Samenvatting
P1 fix voor engine v2: het matchpercentage was opgeblazen en de archetype-filter te slap, waardoor outfits met zwakke fit alsnog >70% scoorden en off-archetype producten soms doorheen slipten.

## Wijzigingen
- **`engine.ts:82-86`** — match-percentage formule van `58 + raw*40` (clamp [55,98]) naar `30 + raw*65` (clamp [30,98]). Resultaat:
  - raw 0.35 → 53% (was 72%)
  - raw 0.5 → 63% (was 78%)
  - raw 0.8 → 82% (was 90%)
  - raw 1.0 → 95% (was 98%)
- **`scoring/index.ts:82`** — archetype penalty steiler: `<0.2 → 0.6`, `<0.35 → 0.85`, anders `1`. Voorheen slechts 10% straf bij `<0.2`, waardoor bv. een Nike tech-tee met toevallig neutrale kleur in een minimalist-outfit kon landen.
- **`scoring/archetype.ts:13`** — token-score noemer van `Math.min(3, needles.length)` naar `Math.min(2, needles.length)`. Een perfect minimalistisch product (COS wit t-shirt, katoen) scoort nu geen ~0.41 meer op archetypefit.

## Testplan
- [x] `npm run build` groen
- [ ] Quiz draaien met minimalist-profiel en controleren of COS/Arket items nu sterker scoren
- [ ] Controleren of laag-scorende outfits geen >70% meer tonen
- [ ] Verifiëren dat off-archetype producten (Nike tech-tee in minimalist) niet meer in composities landen

🤖 Generated with [Claude Code](https://claude.com/claude-code)