### PR TITLE
fix(engine/v2): prints scoring, casual bias, global outfit dedup

### DIFF
--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -89,7 +89,7 @@ const DEFAULT_ARCHETYPES: ArchetypeWeights = {
 const OCCASION_ARCHETYPE_BIAS: Record<OccasionKey, ArchetypeWeights> = {
   work: { BUSINESS: 0.25, CLASSIC: 0.2, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
   formal: { BUSINESS: 0.4, CLASSIC: 0.2, MINIMALIST: 0.05 },
-  casual: { SMART_CASUAL: 0.15, STREETWEAR: 0.1 },
+  casual: { SMART_CASUAL: 0.2, CLASSIC: 0.1 },
   date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
   travel: { SMART_CASUAL: 0.2, MINIMALIST: 0.15 },
   sport: { ATHLETIC: 0.5 },

--- a/src/engine/v2/diversify.ts
+++ b/src/engine/v2/diversify.ts
@@ -57,7 +57,7 @@ export function diversifyOutfits(
   for (const cand of sorted) {
     if (selected.length >= options.count) break;
 
-    const tooSimilar = selected.some((s) => productOverlap(s, cand) > 0.5);
+    const tooSimilar = selected.some((s) => productOverlap(s, cand) > 0.34);
     if (tooSimilar) continue;
 
     const archSig = archetypeSignature(cand);

--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -205,10 +205,21 @@ export function runEngineV2(
   const perOccasion = Math.max(3, Math.ceil(count * 1.5));
   const poolSize = 14;
 
-  const { allCandidates, byOccasion } = composeOutfits(filter, profile, {
+  const { allCandidates: rawCandidates, byOccasion } = composeOutfits(filter, profile, {
     perOccasion,
     poolSize,
     seed,
+  });
+
+  const seenGlobalSignatures = new Set<string>();
+  const allCandidates = rawCandidates.filter((cand) => {
+    const signature = cand.products
+      .map((p) => p.product.id)
+      .sort()
+      .join('|');
+    if (seenGlobalSignatures.has(signature)) return false;
+    seenGlobalSignatures.add(signature);
+    return true;
   });
 
   const diversified = diversifyOutfits(allCandidates, {

--- a/src/engine/v2/scoring/prints.ts
+++ b/src/engine/v2/scoring/prints.ts
@@ -20,10 +20,39 @@ const PRINT_MARKERS = [
   'zebra',
   'logo',
   'allover',
+  'stip',
+  'dot',
+  'polka',
 ];
 
-function hasPrint(product: ScoredProduct): boolean {
-  const text = [
+const SUBTLE_PRINT_MARKERS = [
+  'bloemen',
+  'floral',
+  'stip',
+  'dot',
+  'polka',
+  'streep',
+  'stripe',
+  'gestreept',
+  'ruit',
+  'check',
+  'tartan',
+];
+
+const LOUD_PRINT_MARKERS = [
+  'graphic',
+  'camo',
+  'animal',
+  'leopard',
+  'zebra',
+  'allover logo',
+  'allover-logo',
+  'all-over logo',
+  'allover print',
+];
+
+function productText(product: ScoredProduct): string {
+  return [
     product.product.name,
     product.product.description,
     ...(product.product.tags ?? []),
@@ -31,7 +60,10 @@ function hasPrint(product: ScoredProduct): boolean {
   ]
     .join(' ')
     .toLowerCase();
-  return PRINT_MARKERS.some((m) => text.includes(m));
+}
+
+function matchesAny(text: string, markers: string[]): boolean {
+  return markers.some((m) => text.includes(m));
 }
 
 export function scorePrints(
@@ -39,7 +71,8 @@ export function scorePrints(
   profile: UserStyleProfile
 ): { score: number; reason: string } {
   if (!profile.prints) return { score: 0.7, reason: 'no_prints_pref' };
-  const printed = hasPrint(product);
+  const text = productText(product);
+  const printed = matchesAny(text, PRINT_MARKERS);
 
   if (profile.prints === 'effen') {
     return printed
@@ -52,9 +85,16 @@ export function scorePrints(
       : { score: 0.55, reason: 'prints_statement_plain' };
   }
   if (profile.prints === 'subtiel') {
-    return printed
-      ? { score: 0.7, reason: 'prints_subtiel_busy' }
-      : { score: 0.9, reason: 'prints_subtiel_plain' };
+    if (!printed) {
+      return { score: 0.65, reason: 'prints_subtiel_plain' };
+    }
+    if (matchesAny(text, LOUD_PRINT_MARKERS)) {
+      return { score: 0.45, reason: 'prints_subtiel_too_loud' };
+    }
+    if (matchesAny(text, SUBTLE_PRINT_MARKERS)) {
+      return { score: 1.0, reason: 'prints_subtiel_whitelist_match' };
+    }
+    return { score: 0.95, reason: 'prints_subtiel_match' };
   }
   return { score: 0.75, reason: 'prints_gemengd' };
 }


### PR DESCRIPTION
## Summary

Three interlocking logic fixes in engine v2 that were misaligning results for classic-leaning profiles and allowing duplicate outfits across occasions.

- **Prints scoring was inverted for `subtiel`**: a printed item scored 0.70 and a plain item 0.90, even though \"subtiel\" means the user *wants* prints (just rustig). Flipped to printed 0.95 / plain 0.65, with a whitelist (`bloemen`, `stip`, `streep`, `ruit`) boosted to 1.0 and a blacklist (`graphic`, `camo`, `animal`, `allover logo`) dropped to 0.45.
- **Casual occasion was injecting streetwear**: `OCCASION_ARCHETYPE_BIAS.casual` contained `STREETWEAR: 0.1`, which pulled e.g. a 55-year-old classic-leaning woman toward streetwear just because she picked casual. Replaced with `SMART_CASUAL: 0.2 + CLASSIC: 0.1`.
- **No global outfit dedup**: `seenSignatures` in `composer.ts` was scoped per-occasion, so the same top+bottom+shoes combo could surface under both \"Werk\" and \"Casual\". Added a global signature filter in `engine.ts` right after `composeOutfits`, and tightened the diversify overlap threshold from `>0.5` to `>0.34` so 3-item outfits sharing 2 items are also caught.

## Test plan

- [x] `npm run build` succeeds
- [ ] Run the quiz as a classic-leaning female user with casual occasion and confirm no streetwear items surface
- [ ] Run the quiz with `prints: subtiel` and confirm subtle prints (stripes, small florals) rank above plain items, while graphics/camo are penalized
- [ ] Confirm the same outfit does not appear under two different occasions in the results view

🤖 Generated with [Claude Code](https://claude.com/claude-code)