### PR TITLE
fix(engine/v2): symmetrische archetype mapping + gebalanceerde occasion bias

### DIFF
--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -16,10 +16,10 @@ import type {
 
 const QUIZ_STYLE_TO_ARCHETYPE: Record<string, ArchetypeWeights> = {
   minimalist: { MINIMALIST: 1.0 },
-  classic: { CLASSIC: 0.7, BUSINESS: 0.2, MINIMALIST: 0.1 },
+  classic: { CLASSIC: 1.0 },
   streetwear: { STREETWEAR: 1.0 },
-  'smart-casual': { SMART_CASUAL: 1.0 },
-  smart_casual: { SMART_CASUAL: 1.0 },
+  'smart-casual': { SMART_CASUAL: 0.7, CLASSIC: 0.3 },
+  smart_casual: { SMART_CASUAL: 0.7, CLASSIC: 0.3 },
   athletic: { ATHLETIC: 1.0 },
   sporty: { ATHLETIC: 1.0 },
   rugged: { SMART_CASUAL: 0.5, STREETWEAR: 0.5 },
@@ -87,10 +87,10 @@ const DEFAULT_ARCHETYPES: ArchetypeWeights = {
 };
 
 const OCCASION_ARCHETYPE_BIAS: Record<OccasionKey, ArchetypeWeights> = {
-  work: { BUSINESS: 0.25, CLASSIC: 0.2, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
+  work: { BUSINESS: 0.15, CLASSIC: 0.25, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
   formal: { BUSINESS: 0.4, CLASSIC: 0.2, MINIMALIST: 0.05 },
-  casual: { SMART_CASUAL: 0.2, CLASSIC: 0.1 },
-  date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
+  casual: { SMART_CASUAL: 0.2, CLASSIC: 0.1, AVANT_GARDE: 0.1, STREETWEAR: 0.1 },
+  date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1, AVANT_GARDE: 0.1 },
   travel: { SMART_CASUAL: 0.2, MINIMALIST: 0.15 },
   sport: { ATHLETIC: 0.5 },
 };


### PR DESCRIPTION
## Summary

Twee gekoppelde fixes in \`src/engine/v2/buildProfile.ts\` om scheefheid in quiz→archetype mapping en occasion bias recht te trekken.

### Fix 1 — QUIZ_STYLE_TO_ARCHETYPE symmetrisch
- \`classic\`: **1.0 CLASSIC** (was verdeeld: 0.7 CLASSIC / 0.2 BUSINESS / 0.1 MINIMALIST). Een gebruiker die \"classic\" kiest moet vol op CLASSIC landen, niet gedeeltelijk in BUSINESS belanden.
- \`smart-casual\` / \`smart_casual\`: **0.7 SMART_CASUAL + 0.3 CLASSIC** (was pure 1.0 SC). Smart-casual en classic overlappen in praktijk; deze 30% bleed voorkomt te smalle resultaten.

### Fix 2 — OCCASION_ARCHETYPE_BIAS balans
- **work**: BUSINESS 0.25 → **0.15**, CLASSIC 0.2 → **0.25**. Niet iedereen die \"werk\" selecteert wil een pak — klassieke office-looks krijgen voorrang.
- **casual**: + \`AVANT_GARDE: 0.1\`, + \`STREETWEAR: 0.1\`. Casual was te smal gebiast richting SC/CLASSIC.
- **date**: + \`AVANT_GARDE: 0.1\`. Ruimte voor expressievere date-looks.

## Test plan
- [ ] Quiz afronden met \"classic\" als topkeuze → verwacht dominant CLASSIC outfits, geen BUSINESS in top 3
- [ ] Quiz afronden met \"smart-casual\" + \"werk\" occasion → verwacht mix van SC en CLASSIC, niet BUSINESS-zwaar
- [ ] Quiz met \"casual\" occasion → verwacht diversere archetypes incl. STREETWEAR/AVANT_GARDE opties
- [ ] \`npm run build\` groen (geverifieerd: ✓ built in 11.60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)