### PR TITLE
fix(engine/v2): archetype-aware formality-spread in coherence

### DIFF
--- a/src/engine/v2/coherence.ts
+++ b/src/engine/v2/coherence.ts
@@ -11,7 +11,51 @@ export interface CoherenceScores {
   reasons: string[];
 }
 
-export function evaluateCoherence(products: ScoredProduct[]): CoherenceScores {
+interface SpreadThresholds {
+  hardPenalty: number;
+  midPenalty: number;
+  softPenalty: number;
+  mismatchReason: number;
+  coherentReason: number;
+}
+
+const DEFAULT_SPREAD_THRESHOLDS: SpreadThresholds = {
+  hardPenalty: 0.55,
+  midPenalty: 0.4,
+  softPenalty: 0.25,
+  mismatchReason: 0.45,
+  coherentReason: 0.25,
+};
+
+const SPREAD_THRESHOLDS_BY_ARCHETYPE: Partial<Record<ArchetypeKey, SpreadThresholds>> = {
+  SMART_CASUAL: {
+    hardPenalty: 0.75,
+    midPenalty: 0.65,
+    softPenalty: 0.55,
+    mismatchReason: 0.7,
+    coherentReason: 0.55,
+  },
+  AVANT_GARDE: {
+    hardPenalty: 0.85,
+    midPenalty: 0.78,
+    softPenalty: 0.7,
+    mismatchReason: 0.8,
+    coherentReason: 0.7,
+  },
+};
+
+function spreadThresholdsFor(profile?: UserStyleProfile): SpreadThresholds {
+  if (!profile) return DEFAULT_SPREAD_THRESHOLDS;
+  return (
+    SPREAD_THRESHOLDS_BY_ARCHETYPE[profile.primaryArchetype] ??
+    DEFAULT_SPREAD_THRESHOLDS
+  );
+}
+
+export function evaluateCoherence(
+  products: ScoredProduct[],
+  profile?: UserStyleProfile
+): CoherenceScores {
   const reasons: string[] = [];
   if (products.length === 0) {
     return {
@@ -33,16 +77,17 @@ export function evaluateCoherence(products: ScoredProduct[]): CoherenceScores {
   if (colorHarmony > 0.8) reasons.push('color_harmony_strong');
   else if (colorHarmony < 0.45) reasons.push('color_harmony_weak');
 
+  const thresholds = spreadThresholdsFor(profile);
   const formalities = products.map((p) => p.formality);
   const minF = Math.min(...formalities);
   const maxF = Math.max(...formalities);
   const spread = maxF - minF;
   let formalitySpread = 1;
-  if (spread > 0.55) formalitySpread = 0.35;
-  else if (spread > 0.4) formalitySpread = 0.6;
-  else if (spread > 0.25) formalitySpread = 0.85;
-  if (spread < 0.25) reasons.push('formality_coherent');
-  if (spread > 0.45) reasons.push('formality_mismatch');
+  if (spread > thresholds.hardPenalty) formalitySpread = 0.35;
+  else if (spread > thresholds.midPenalty) formalitySpread = 0.6;
+  else if (spread > thresholds.softPenalty) formalitySpread = 0.85;
+  if (spread < thresholds.coherentReason) reasons.push('formality_coherent');
+  if (spread > thresholds.mismatchReason) reasons.push('formality_mismatch');
 
   const archetypeTotals: Record<string, number> = {};
   for (const p of products) {

--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -132,9 +132,10 @@ function assembleReasons(
 }
 
 function scoreComposition(
-  products: ScoredProduct[]
+  products: ScoredProduct[],
+  profile: UserStyleProfile
 ): { coherence: ReturnType<typeof evaluateCoherence>; score: number } {
-  const coherence = evaluateCoherence(products);
+  const coherence = evaluateCoherence(products, profile);
   const productAvg =
     products.reduce((acc, p) => acc + p.score, 0) / Math.max(1, products.length);
   const baseScore = productAvg * 0.55 + coherence.combined * 0.45;
@@ -274,7 +275,7 @@ function composeForOccasion(
     if (seenSignatures.has(signature)) continue;
     seenSignatures.add(signature);
 
-    const { coherence, score } = scoreComposition(products);
+    const { coherence, score } = scoreComposition(products, profile);
     if (score < 0.35) continue;
 
     candidates.push({


### PR DESCRIPTION
## Summary

Coherence's formality-spread penalty used one global curve, which punishes exactly the looks some archetypes are *supposed* to have:

- **SMART_CASUAL** signature outfits (blazer + tee, tailored trouser + sneaker) intentionally mix a formal and casual item — spread of ~0.45 is normal, but the old curve dropped the score to 0.6 there.
- **AVANT_GARDE** leans on deliberate formality tension; the old curve treated it the same as a classic look.

Fix: `evaluateCoherence` now accepts the `UserStyleProfile` and picks spread thresholds per `primaryArchetype`.

| Archetype | No penalty up to | Mid penalty at | Hard penalty at |
|---|---|---|---|
| SMART_CASUAL | 0.55 (was 0.25) | 0.65 | 0.75 |
| AVANT_GARDE | 0.70 | 0.78 | 0.85 |
| Others | 0.25 (unchanged) | 0.40 | 0.55 |

`scoreComposition` in `composer.ts` now passes the profile through to `evaluateCoherence`. `isHardMismatch` already accepted the profile — no change to that call site.

## Test plan

- [x] \`npm run build\` succeeds
- [ ] Run the quiz as a SMART_CASUAL profile and confirm blazer+tee combos surface (previously filtered/demoted)
- [ ] Run the quiz as an AVANT_GARDE profile and confirm formality-tension outfits are no longer demoted
- [ ] Run the quiz as a CLASSIC profile and confirm spread behavior is unchanged (still penalized above 0.25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)