### PR TITLE
fix(engine,quiz): dedupe olijf color and add party occasion

### DIFF
--- a/src/data/quizSteps.ts
+++ b/src/data/quizSteps.ts
@@ -330,6 +330,11 @@ export const quizSteps: QuizStep[] = [
         value: 'sport',
         label: 'Sport & Actief',
         description: 'Gym, yoga, outdoor activiteiten'
+      },
+      {
+        value: 'party',
+        label: 'Uitgaan / Feest',
+        description: 'Stappen, festivals, feestjes'
       }
     ]
   },

--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -93,6 +93,7 @@ const OCCASION_ARCHETYPE_BIAS: Record<OccasionKey, ArchetypeWeights> = {
   date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
   travel: { SMART_CASUAL: 0.2, MINIMALIST: 0.15 },
   sport: { ATHLETIC: 0.5 },
+  party: { SMART_CASUAL: 0.2, CLASSIC: 0.1 },
 };
 
 function normalizeWeights(weights: ArchetypeWeights): ArchetypeWeights {
@@ -231,6 +232,7 @@ function normalizeOccasions(raw: any): OccasionKey[] {
     'date',
     'travel',
     'sport',
+    'party',
   ];
   if (!Array.isArray(raw)) return [];
   const set = new Set<OccasionKey>();
@@ -241,6 +243,7 @@ function normalizeOccasions(raw: any): OccasionKey[] {
     else if (norm === 'formeel') set.add('formal');
     else if (norm === 'reizen') set.add('travel');
     else if (norm === 'gym' || norm === 'sport & actief') set.add('sport');
+    else if (norm === 'feest' || norm === 'uitgaan' || norm === 'festival' || norm === 'stappen') set.add('party');
   }
   return Array.from(set);
 }

--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -25,6 +25,7 @@ const OCCASION_TARGET_FORMALITY: Record<OccasionKey, number> = {
   date: 0.6,
   travel: 0.4,
   sport: 0.15,
+  party: 0.35,
 };
 
 const OCCASION_WANTS_OUTERWEAR: Record<OccasionKey, number> = {
@@ -34,6 +35,7 @@ const OCCASION_WANTS_OUTERWEAR: Record<OccasionKey, number> = {
   date: 0.3,
   travel: 0.4,
   sport: 0.05,
+  party: 0.15,
 };
 
 const OCCASION_WANTS_ACCESSORY: Record<OccasionKey, number> = {
@@ -43,6 +45,7 @@ const OCCASION_WANTS_ACCESSORY: Record<OccasionKey, number> = {
   date: 0.25,
   travel: 0.1,
   sport: 0.0,
+  party: 0.3,
 };
 
 function seededRandom(seed: number): () => number {

--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -39,6 +39,10 @@ const OCCASION_COPY: Record<OccasionKey, { title: string; description: string }>
     title: 'Actief',
     description: 'Functioneel en sportief voor beweging en gym.',
   },
+  party: {
+    title: 'Uitgaan / Feest',
+    description: 'Expressief en comfortabel voor stappen, festivals of feestjes.',
+  },
 };
 
 function buildOutfitTitle(

--- a/src/engine/v2/scoring/color.ts
+++ b/src/engine/v2/scoring/color.ts
@@ -15,6 +15,7 @@ const WARM_COLORS = new Set([
   'crème',
   'creme',
   'aardetinten',
+  'olijf',
 ]);
 
 // Deep, desaturated tones that read as formal/zakelijk neutrals rather than
@@ -34,7 +35,6 @@ const COOL_COLORS = new Set([
   'kobalt',
   'mint',
   'sage',
-  'olijf',
   'paars',
   'lavendel',
 ]);

--- a/src/engine/v2/scoring/occasion.ts
+++ b/src/engine/v2/scoring/occasion.ts
@@ -10,15 +10,17 @@ export const OCCASION_FORMALITY: Record<
   date: { target: 0.6, tolerance: 0.2 },
   travel: { target: 0.4, tolerance: 0.25 },
   sport: { target: 0.12, tolerance: 0.18 },
+  party: { target: 0.35, tolerance: 0.25 },
 };
 
 const OCCASION_KEYWORDS: Partial<Record<OccasionKey, string[]>> = {
   work: ['werk', 'kantoor', 'office', 'professional', 'blazer', 'overhemd', 'pantalon', 'mantelpak', 'mantelpakje', 'kokerrok', 'pencil skirt', 'blouse', 'pumps', 'blazerjurk', 'shirtdress'],
-  formal: ['formeel', 'formal', 'feest', 'galadiner', 'ceremonie', 'suit', 'pak', 'smoking', 'mantelpak'],
+  formal: ['formeel', 'formal', 'galadiner', 'ceremonie', 'suit', 'pak', 'smoking', 'mantelpak'],
   casual: ['casual', 'relaxed', 'weekend', 'dagelijks', 'jeans', 't-shirt', 'sneaker'],
-  date: ['date', 'uitgaan', 'diner', 'restaurant', 'night out', 'cocktail'],
+  date: ['date', 'diner', 'restaurant', 'night out', 'cocktail'],
   travel: ['travel', 'reizen', 'versatile', 'comfort', 'licht'],
   sport: ['sport', 'gym', 'training', 'running', 'tech', 'performance', 'stretch'],
+  party: ['party', 'feest', 'festival', 'uitgaan', 'club', 'stappen', 'night out', 'rave'],
 };
 
 export function scoreOccasion(

--- a/src/engine/v2/types.ts
+++ b/src/engine/v2/types.ts
@@ -9,7 +9,7 @@ export type TemperatureKey = 'warm' | 'koel' | 'neutraal';
 export type ValueKey = 'licht' | 'medium' | 'donker';
 export type ContrastKey = 'laag' | 'medium' | 'hoog';
 export type ColorSeasonKey = 'lente' | 'zomer' | 'herfst' | 'winter';
-export type OccasionKey = 'work' | 'casual' | 'formal' | 'date' | 'travel' | 'sport';
+export type OccasionKey = 'work' | 'casual' | 'formal' | 'date' | 'travel' | 'sport' | 'party';
 export type GoalKey =
   | 'timeless'
   | 'trendy'


### PR DESCRIPTION
## Summary
- **Bug 1 — olijf dubbel geclassificeerd.** 'olijf' stond in zowel `WARM_COLORS` als `COOL_COLORS` in `src/engine/v2/scoring/color.ts`, waardoor de temperatuur afhing van Set-iteratievolgorde. Olive is groen met gele ondertoon → alleen behouden in WARM. Geen andere cross-bucket duplicaten gevonden.
- **Bug 2 — party-occasion ontbrak end-to-end.** UI (EnhancedResultsPage, OutfitFilters) kende `party` al, maar de quiz en engine v2 niet. Nu volledig ingebouwd.

## Changes
- `engine/v2/types.ts`: `'party'` toegevoegd aan `OccasionKey`.
- `engine/v2/engine.ts`: `OCCASION_COPY['party']` — titel/beschrijving "Uitgaan / Feest".
- `engine/v2/composer.ts`: `party` krijgt `targetFormality: 0.35`, gematigde outerwear/accessoire-weights.
- `engine/v2/scoring/occasion.ts`: `OCCASION_FORMALITY['party'] = { target: 0.35, tolerance: 0.25 }`; keywords `party, feest, festival, uitgaan, club, stappen, night out, rave`. 'feest' verwijderd uit formal en 'uitgaan' uit date (stonden daar verkeerd).
- `engine/v2/buildProfile.ts`: archetype-bias voor party (SMART_CASUAL, CLASSIC); normalizer accepteert aliassen feest/uitgaan/festival/stappen.
- `data/quizSteps.ts`: nieuwe optie "Uitgaan / Feest" bij de occasions-vraag.
- `engine/v2/scoring/color.ts`: `olijf` uit COOL_COLORS, naar WARM_COLORS.

## Test plan
- [ ] `npm run build` slaagt (bevestigd lokaal)
- [ ] Quiz toont "Uitgaan / Feest" als keuze bij occasions
- [ ] Outfits met `party`-occasion worden nu gecomponeerd (i.p.v. naar casual te vallen)
- [ ] Olijf-producten scoren consistent als warm tegen warm-paletprofielen

🤖 Generated with [Claude Code](https://claude.com/claude-code)