### PR TITLE
fix(engine/v2): symmetrische archetype mapping + gebalanceerde occasion bias

### DIFF
--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -166,14 +166,20 @@ function moodboardToArchetypes(
 
 function applyOccasionBias(
   weights: ArchetypeWeights,
-  occasions: OccasionKey[]
+  occasions: OccasionKey[],
+  goals: GoalKey[] = []
 ): ArchetypeWeights {
   if (occasions.length === 0) return weights;
+  const minimalGoal = goals.includes('minimal');
   let acc = { ...weights };
   for (const occ of occasions) {
     const bias = OCCASION_ARCHETYPE_BIAS[occ];
     if (!bias) continue;
-    acc = mergeWeights(acc, bias, 1);
+    const adjusted =
+      occ === 'work' && minimalGoal && typeof bias.BUSINESS === 'number'
+        ? { ...bias, BUSINESS: bias.BUSINESS * 0.5 }
+        : bias;
+    acc = mergeWeights(acc, adjusted, 1);
   }
   return normalizeWeights(acc);
 }
@@ -475,7 +481,7 @@ export function buildUserStyleProfile(
     ? blendWeights(quizBase, swipeArchetypes, swipeInfluence)
     : normalizeWeights(quizBase);
 
-  blended = applyOccasionBias(blended, occasions);
+  blended = applyOccasionBias(blended, occasions, goals);
   const { primary, secondary } = pickTopArchetypes(blended);
 
   return {

--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -16,10 +16,10 @@ import type {
 
 const QUIZ_STYLE_TO_ARCHETYPE: Record<string, ArchetypeWeights> = {
   minimalist: { MINIMALIST: 1.0 },
-  classic: { CLASSIC: 0.7, BUSINESS: 0.2, MINIMALIST: 0.1 },
+  classic: { CLASSIC: 1.0 },
   streetwear: { STREETWEAR: 1.0 },
-  'smart-casual': { SMART_CASUAL: 1.0 },
-  smart_casual: { SMART_CASUAL: 1.0 },
+  'smart-casual': { SMART_CASUAL: 0.7, CLASSIC: 0.3 },
+  smart_casual: { SMART_CASUAL: 0.7, CLASSIC: 0.3 },
   athletic: { ATHLETIC: 1.0 },
   sporty: { ATHLETIC: 1.0 },
   rugged: { SMART_CASUAL: 0.5, STREETWEAR: 0.5 },
@@ -87,10 +87,10 @@ const DEFAULT_ARCHETYPES: ArchetypeWeights = {
 };
 
 const OCCASION_ARCHETYPE_BIAS: Record<OccasionKey, ArchetypeWeights> = {
-  work: { BUSINESS: 0.25, CLASSIC: 0.2, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
+  work: { BUSINESS: 0.15, CLASSIC: 0.25, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
   formal: { BUSINESS: 0.4, CLASSIC: 0.2, MINIMALIST: 0.05 },
-  casual: { SMART_CASUAL: 0.2, CLASSIC: 0.1 },
-  date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1 },
+  casual: { SMART_CASUAL: 0.2, CLASSIC: 0.1, AVANT_GARDE: 0.1, STREETWEAR: 0.1 },
+  date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1, AVANT_GARDE: 0.1 },
   travel: { SMART_CASUAL: 0.2, MINIMALIST: 0.15 },
   sport: { ATHLETIC: 0.5 },
 };


### PR DESCRIPTION
## Summary

Twee structurele problemen uit de engine-audit opgelost in `src/engine/v2/buildProfile.ts`.

### 1. Symmetrische `QUIZ_STYLE_TO_ARCHETYPE` mapping
- `classic` → pure `{ CLASSIC: 1.0 }` (was verdeeld 0.7/0.2/0.1 over CLASSIC/BUSINESS/MINIMALIST)
- `smart-casual` → `{ SMART_CASUAL: 0.7, CLASSIC: 0.3 }` (was pure 1.0)
- Resultaat: iemand die `classic + smart-casual` kiest krijgt nu CLASSIC als primary (was SMART_CASUAL door asymmetrie).

### 2. Gebalanceerde `OCCASION_ARCHETYPE_BIAS`
- `work`: `BUSINESS` 0.25 → 0.15, `CLASSIC` 0.2 → 0.25 (minder agressieve business-push)
- `casual`: `+ AVANT_GARDE 0.1`, `+ STREETWEAR 0.1` (meer variatie)
- `date`: `+ AVANT_GARDE 0.1` (ruimte voor expressievere date-looks)
- AVANT_GARDE zat in géén enkele occasion-bias → werd altijd verdund zodra iemand een occasion koos. Nu aanwezig in `casual` + `date`.

### 3. Minimalisten beschermen tegen work-bias
Wanneer `goals` de waarde `minimal` bevat én `occ === 'work'`, wordt alleen de BUSINESS-component van de work-bias gehalveerd (0.15 → 0.075). Andere componenten (CLASSIC, SMART_CASUAL, MINIMALIST) blijven volledig staan. Voorkomt dat minimalisten met een werkprofiel richting BUSINESS getrokken worden.

## Test plan

- [ ] Quiz met `classic + smart-casual` → primary = CLASSIC
- [ ] Quiz met `avant-garde + casual` → AVANT_GARDE blijft in top-2 na occasion-bias
- [ ] Quiz met `goals=minimal + occasions=[work]` → primary blijft MINIMALIST-georiënteerd, geen BUSINESS-dominantie
- [ ] Quiz met `goals=[]` + `occasions=[work]` → gedrag ongewijzigd t.o.v. f2230c93 (backwards-compat)
- [ ] `npm run build` slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)