### PR TITLE
hotfix(engine/v2): verwijder destructieve archetype-coherence gate + voeg minimal goal toe

### DIFF
--- a/src/engine/v2/coherence.ts
+++ b/src/engine/v2/coherence.ts
@@ -162,17 +162,5 @@ export function isHardMismatch(
     if (!profileAcceptsAthletic) return true;
   }
 
-  const archetypeTotals: Record<string, number> = {};
-  for (const p of products) {
-    for (const [key, score] of Object.entries(p.archetypeFit)) {
-      archetypeTotals[key] = (archetypeTotals[key] ?? 0) + (score ?? 0);
-    }
-  }
-  const sum = Object.values(archetypeTotals).reduce((a, b) => a + b, 0);
-  if (sum > 0) {
-    const top = Math.max(...Object.values(archetypeTotals));
-    if (top / sum < 0.35) return true;
-  }
-
   return false;
 }

--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -64,6 +64,7 @@ const GOAL_ADJECTIVE: Partial<Record<GoalKey, string>> = {
   timeless: 'tijdloze',
   professional: 'professionele',
   express: 'expressieve',
+  minimal: 'minimalistische',
 };
 
 const TEMPERATURE_SENTENCE: Record<TemperatureKey, string> = {
@@ -73,7 +74,7 @@ const TEMPERATURE_SENTENCE: Record<TemperatureKey, string> = {
 };
 
 function primaryGoalAdjective(goals: GoalKey[]): string | null {
-  for (const key of ['timeless', 'professional', 'express'] as GoalKey[]) {
+  for (const key of ['timeless', 'professional', 'express', 'minimal'] as GoalKey[]) {
     if (goals.includes(key)) return GOAL_ADJECTIVE[key] ?? null;
   }
   return null;


### PR DESCRIPTION
## Summary

Twee hotfixes: één kritieke bug die resultaten leegmaakte, één kleine UX-fix voor explanation copy.

### Bug 1 (KRITIEK) — \`src/engine/v2/coherence.ts\`
\`isHardMismatch\` weigerde **alle** outfits:
- \`scoreProductArchetype\` geeft via formality-baseline elke archetype een non-zero score
- Daardoor bleef \`top / sum\` mathematisch capped rond ~0.30
- De threshold \`< 0.35\` → elke outfit viel eruit → gebruikers zagen 0 resultaten

**Fix:** harde archetype-coherence gate volledig verwijderd. De archetype-scoring penalty die in PR #28 is toegevoegd (0.6× bij <0.2 archetype fit) doet dit werk al in de ranking — de harde gate is redundant en destructief.

### Bug 2 — \`src/engine/v2/engine.ts\`
\`GOAL_ADJECTIVE\` miste \`minimal\`. Daan's primaire goal werd stilzwijgend genegeerd in de outfit explanation.

**Fix:** \`minimal: 'minimalistische'\` toegevoegd aan de map én aan de priority-iteratie in \`primaryGoalAdjective\`.

## Test plan
- [ ] Quiz afronden met willekeurig profiel → outfits verschijnen (voorheen: 0)
- [ ] Quiz met \`minimal\` als primary goal → explanation bevat \"minimalistische\"
- [ ] \`npm run build\` groen (geverifieerd: ✓ built in 9.32s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)