### PR TITLE
fix(engine+ui): toon materiaal in outfit-uitleg en laat de tweede zin zien

### DIFF
--- a/src/components/results/ResultsOutfitCard.tsx
+++ b/src/components/results/ResultsOutfitCard.tsx
@@ -91,8 +91,8 @@ export function ResultsOutfitCard({
           {name}
         </h3>
 
-        {/* Description — single line */}
-        <p className="text-sm text-[#4A4A4A] leading-[1.5] line-clamp-1 mb-3">
+        {/* Description — up to two lines */}
+        <p className="text-sm text-[#4A4A4A] leading-[1.5] line-clamp-2 mb-3">
           {description}
         </p>
 

--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -74,10 +74,16 @@ const TEMPERATURE_SENTENCE: Record<TemperatureKey, string> = {
 };
 
 function primaryGoalAdjective(goals: GoalKey[]): string | null {
-  for (const key of ['timeless', 'professional', 'express', 'minimal'] as GoalKey[]) {
-    if (goals.includes(key)) return GOAL_ADJECTIVE[key] ?? null;
+  const priority: GoalKey[] = ['timeless', 'professional', 'express', 'minimal'];
+  const matched: string[] = [];
+  for (const key of priority) {
+    if (!goals.includes(key)) continue;
+    const adj = GOAL_ADJECTIVE[key];
+    if (adj) matched.push(adj);
+    if (matched.length === 2) break;
   }
-  return null;
+  if (matched.length === 0) return null;
+  return matched.join(' en ');
 }
 
 function matchedPreferredMaterial(
@@ -107,12 +113,12 @@ function buildExplanation(
   const goal = primaryGoalAdjective(profile.goals);
   if (goal) signals.push(`Afgestemd op je ${goal} stijl.`);
 
+  const material = matchedPreferredMaterial(candidate, profile);
+  if (material) signals.push(`Met je voorkeur voor ${material}.`);
+
   if (profile.color.temperature) {
     signals.push(TEMPERATURE_SENTENCE[profile.color.temperature]);
   }
-
-  const material = matchedPreferredMaterial(candidate, profile);
-  if (material) signals.push(`Met je voorkeur voor ${material}.`);
 
   if (candidate.coherence.completeness >= 1) {
     signals.push('Compleet van top tot schoen.');
@@ -127,7 +133,7 @@ function buildExplanation(
     return `Afgestemd op je ${primary}-voorkeur.`;
   }
 
-  return signals.slice(0, 2).join(' ');
+  return signals.slice(0, 3).join(' ');
 }
 
 function buildMatchPercentage(candidate: OutfitCandidate): number {

--- a/src/pages/EnhancedResultsPage.tsx
+++ b/src/pages/EnhancedResultsPage.tsx
@@ -1611,7 +1611,7 @@ export default function EnhancedResultsPage() {
                         <h3 className="text-base font-semibold text-[#1A1A1A] mb-1.5 group-hover:text-[#C2654A] transition-colors duration-200">
                           {'name' in outfit ? outfit.name : outfitInfo.title}
                         </h3>
-                        <p className="text-sm text-[#4A4A4A] leading-[1.5] line-clamp-1 mb-3">
+                        <p className="text-sm text-[#4A4A4A] leading-[1.5] line-clamp-2 mb-3">
                           {('explanation' in outfit && outfit.explanation)
                             ? (outfit.explanation as string)
                             : outfitInfo.description}


### PR DESCRIPTION
## Samenvatting
Drie samenhangende fixes zodat de gepersonaliseerde outfit-uitleg de gebruiker daadwerkelijk bereikt.

## Wijzigingen

### \`src/engine/v2/engine.ts\` — buildExplanation

1. **Prioriteit goal → material → temperature**, en maximaal 3 signalen in plaats van 2. Materiaal is concreter en persoonlijker dan kleurtemperatuur, maar verdween altijd omdat goal + temperature de twee slots vulden.
2. **primaryGoalAdjective combineert tot twee goals** — goals \`[timeless, professional]\` geeft nu \"tijdloze en professionele stijl\" in plaats van alleen de eerste match.

### UI — line-clamp-1 → line-clamp-2

Twee plekken waar de beschrijving op 1 regel werd afgekapt:
- \`src/pages/EnhancedResultsPage.tsx:1614\` (inline outfit-card)
- \`src/components/results/ResultsOutfitCard.tsx:95\` (herbruikbare kaart)

Beide tonen nu tot twee regels, zodat de tweede zin van de explanation zichtbaar is.

## Testplan
- [x] \`npm run build\` groen
- [ ] Quiz met goals \`[timeless, professional]\` + materiaal-match → \"Afgestemd op je tijdloze en professionele stijl. Met je voorkeur voor wol. In je koele kleurpalet.\"
- [ ] Outfit-card toont twee regels beschrijving zonder layout-shift
- [ ] Langere explanation wordt netjes na 2 regels afgekapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)