### PR TITLE
fix(engine): per-occasion scoring, party-bias streetwear, oxford shirt

### DIFF
--- a/src/engine/productClassifier.ts
+++ b/src/engine/productClassifier.ts
@@ -177,7 +177,15 @@ const BOTTOM_RULES: PatternEntry[] = [
 
 // ─── TOP ──────────────────────────────────────────────────────────────────
 // jersey, prematch, short sleeve → always TOP, never bottom
+// "oxford" in a shirt-context (cotton/shirt/button/overhemd/blouse) is an
+// oxford shirt, not an oxford shoe — matched in either word order.
 const TOP_RULES: PatternEntry[] = [
+  {
+    regex:
+      /\b(?:shirt|cotton|button|overhemd|blouse)\b[\s\S]*\boxford\b|\boxford\b[\s\S]*\b(?:shirt|cotton|button|overhemd|blouse)\b/i,
+    subcategory: 'oxford shirt',
+    weight: 3,
+  },
   { regex: /\bt-shirt\b|\btshirt\b/i, subcategory: 't-shirt', weight: 3 },
   { regex: /\boverhemd\b/i, subcategory: 'overhemd', weight: 3 },
   { regex: /\bblouse\b/i, subcategory: 'blouse', weight: 3 },
@@ -304,7 +312,17 @@ export function classifyProductDetailed(
   const nameMatches: MatchResult[] = [];
   const fullMatches: MatchResult[] = [];
 
-  for (const [category, rules] of ORDERED_RULES) {
+  const hasShirtContext = /\b(?:shirt|cotton|button|overhemd|blouse)\b/i.test(
+    fullText
+  );
+  const activeRules: Array<[string, PatternEntry[]]> = ORDERED_RULES.map(
+    ([cat, rules]) =>
+      cat === 'footwear' && hasShirtContext
+        ? [cat, rules.filter((r) => r.subcategory !== 'oxfords')]
+        : [cat, rules]
+  );
+
+  for (const [category, rules] of activeRules) {
     const nameScore = scoreText(nameText, rules);
     if (nameScore) nameMatches.push({ category, ...nameScore });
 

--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -93,7 +93,7 @@ const OCCASION_ARCHETYPE_BIAS: Record<OccasionKey, ArchetypeWeights> = {
   date: { CLASSIC: 0.15, SMART_CASUAL: 0.15, MINIMALIST: 0.1, AVANT_GARDE: 0.1 },
   travel: { SMART_CASUAL: 0.2, MINIMALIST: 0.15 },
   sport: { ATHLETIC: 0.5 },
-  party: { SMART_CASUAL: 0.2, CLASSIC: 0.1 },
+  party: { STREETWEAR: 0.2, SMART_CASUAL: 0.15, AVANT_GARDE: 0.1, CLASSIC: 0.05 },
 };
 
 function normalizeWeights(weights: ArchetypeWeights): ArchetypeWeights {

--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -65,15 +65,20 @@ function shuffleSeeded<T>(items: T[], rand: () => number): T[] {
   return out;
 }
 
+function scoreFor(product: ScoredProduct, occasion: OccasionKey): number {
+  return product.scoreByOccasion?.[occasion] ?? product.score;
+}
+
 function rankForOccasion(
   products: ScoredProduct[],
-  targetFormality: number
+  targetFormality: number,
+  occasion: OccasionKey
 ): ScoredProduct[] {
   return [...products].sort((a, b) => {
     const aDist = Math.abs(a.formality - targetFormality);
     const bDist = Math.abs(b.formality - targetFormality);
-    const aScore = a.score - aDist * 0.25;
-    const bScore = b.score - bDist * 0.25;
+    const aScore = scoreFor(a, occasion) - aDist * 0.25;
+    const bScore = scoreFor(b, occasion) - bDist * 0.25;
     return bScore - aScore;
   });
 }
@@ -82,9 +87,10 @@ function pickTopPool(
   products: ScoredProduct[],
   targetFormality: number,
   poolSize: number,
-  rand: () => number
+  rand: () => number,
+  occasion: OccasionKey
 ): ScoredProduct[] {
-  const ranked = rankForOccasion(products, targetFormality);
+  const ranked = rankForOccasion(products, targetFormality, occasion);
   const pool = ranked.slice(0, Math.max(poolSize, 4));
   return shuffleSeeded(pool, rand);
 }
@@ -136,11 +142,13 @@ function assembleReasons(
 
 function scoreComposition(
   products: ScoredProduct[],
-  profile: UserStyleProfile
+  profile: UserStyleProfile,
+  occasion: OccasionKey
 ): { coherence: ReturnType<typeof evaluateCoherence>; score: number } {
   const coherence = evaluateCoherence(products, profile);
   const productAvg =
-    products.reduce((acc, p) => acc + p.score, 0) / Math.max(1, products.length);
+    products.reduce((acc, p) => acc + scoreFor(p, occasion), 0) /
+    Math.max(1, products.length);
   const baseScore = productAvg * 0.55 + coherence.combined * 0.45;
   const multiplier = coherenceMultiplier(coherence) * brandPenalty(products);
   return { coherence, score: Math.max(0, Math.min(1, baseScore * multiplier)) };
@@ -226,25 +234,26 @@ function composeForOccasion(
 
     let picks: Parameters<typeof tryCompose>[0] = {};
     if (useDress) {
-      const pool = pickTopPool(byCategory.dress, targetFormality, poolSize, rand);
+      const pool = pickTopPool(byCategory.dress, targetFormality, poolSize, rand, occasion);
       picks.dress = pool[0];
     } else if (useJumpsuit) {
-      const pool = pickTopPool(byCategory.jumpsuit, targetFormality, poolSize, rand);
+      const pool = pickTopPool(byCategory.jumpsuit, targetFormality, poolSize, rand, occasion);
       picks.dress = pool[0];
     } else {
-      const topPool = pickTopPool(byCategory.top, targetFormality, poolSize, rand);
+      const topPool = pickTopPool(byCategory.top, targetFormality, poolSize, rand, occasion);
       const bottomPool = pickTopPool(
         byCategory.bottom,
         targetFormality,
         poolSize,
-        rand
+        rand,
+        occasion
       );
       picks.top = topPool[0];
       picks.bottom = bottomPool[0];
     }
 
     if (byCategory.footwear.length > 0) {
-      const pool = pickTopPool(byCategory.footwear, targetFormality, poolSize, rand);
+      const pool = pickTopPool(byCategory.footwear, targetFormality, poolSize, rand, occasion);
       picks.footwear = pool[0];
     }
 
@@ -253,7 +262,8 @@ function composeForOccasion(
         byCategory.outerwear,
         targetFormality,
         Math.max(3, Math.floor(poolSize / 2)),
-        rand
+        rand,
+        occasion
       );
       picks.outerwear = pool[0];
     }
@@ -263,7 +273,8 @@ function composeForOccasion(
         byCategory.accessory,
         targetFormality,
         Math.max(3, Math.floor(poolSize / 2)),
-        rand
+        rand,
+        occasion
       );
       picks.accessory = pool[0];
     }
@@ -278,7 +289,7 @@ function composeForOccasion(
     if (seenSignatures.has(signature)) continue;
     seenSignatures.add(signature);
 
-    const { coherence, score } = scoreComposition(products, profile);
+    const { coherence, score } = scoreComposition(products, profile, occasion);
     if (score < 0.35) continue;
 
     candidates.push({

--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -242,10 +242,19 @@ export function runEngineV2(
     });
   }
 
-  const primaryOccasion: OccasionKey =
-    profile.occasions[0] ?? 'casual';
+  const scoringOccasions: OccasionKey[] =
+    profile.occasions.length > 0 ? profile.occasions : ['casual'];
+  const primaryOccasion: OccasionKey = scoringOccasions[0];
+
   for (const scored of filter.candidates) {
+    scored.scoreByOccasion = {};
+    for (const occ of scoringOccasions) {
+      if (occ === primaryOccasion) continue;
+      computeProductScore(scored, profile, occ, season);
+      scored.scoreByOccasion[occ] = scored.score;
+    }
     computeProductScore(scored, profile, primaryOccasion, season);
+    scored.scoreByOccasion[primaryOccasion] = scored.score;
   }
 
   Object.values(filter.byCategory).forEach((list) => {

--- a/src/engine/v2/types.ts
+++ b/src/engine/v2/types.ts
@@ -101,6 +101,7 @@ export interface ScoredProduct {
   product: Product;
   category: NormalizedCategory;
   score: number;
+  scoreByOccasion?: Partial<Record<OccasionKey, number>>;
   breakdown: ScoreBreakdown;
   reasons: string[];
   formality: number;


### PR DESCRIPTION
## Summary

Three engine-logic fixes that ship together because they all touch outfit composition.

### 1. Per-occasion product scoring (biggest impact)

Every product was scored once against \`profile.occasions[0]\` — usually \`work\` — and that single score fed every occasion pool. So when the composer picked a 'casual' outfit, it was pulling from products ranked by their work-fit score.

Fix: the scoring loop now iterates \`profile.occasions\` and populates \`scoreByOccasion[occ]\` on each product. The composer's \`rankForOccasion\` and \`scoreComposition\` read the occasion-specific score.

- \`types.ts\` — new optional \`scoreByOccasion\` field on \`ScoredProduct\`
- \`engine.ts\` — loop scoring over each occasion; leaves \`product.score\` canonical as the primary-occasion score so downstream sort-by-score still works
- \`composer.ts\` — \`rankForOccasion\` / \`pickTopPool\` / \`scoreComposition\` take \`occasion\` and read \`scoreByOccasion[occasion] ?? score\`

### 2. Party bias was missing streetwear

\`OCCASION_ARCHETYPE_BIAS.party\` was \`{ SMART_CASUAL: 0.2, CLASSIC: 0.1 }\`, which isn't what people wear to a club. Changed to \`{ STREETWEAR: 0.2, SMART_CASUAL: 0.15, AVANT_GARDE: 0.1, CLASSIC: 0.05 }\`.

### 3. Oxford disambiguation

\"Tommy Slim Cotton Oxford\" (a shirt) was matching the oxford-footwear rule. Two changes in \`productClassifier.ts\`:
- The oxford-footwear rule is skipped when text contains any of \`shirt / cotton / button / overhemd / blouse\`
- A new TOP rule matches \`oxford\` paired with those context words in either order (\"cotton oxford\" or \"oxford shirt\")

## Test plan

- [x] \`npm run build\` succeeds
- [ ] Run the quiz with occasions = [work, casual] and verify casual pool isn't dominated by work-leaning items
- [ ] Run with occasion = party and confirm STREETWEAR items surface
- [ ] Pass \"Tommy Slim Cotton Oxford\" through \`classifyProductDetailed\` and confirm category = \`top\`, subcategory = \`oxford shirt\`
- [ ] Pass \"Cole Haan Oxford Shoes\" and confirm it still classifies as \`footwear\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)