### PR TITLE
feat(quiz): multiselect neutrals + budget range + brand preferences

### DIFF
--- a/src/data/quizSteps.ts
+++ b/src/data/quizSteps.ts
@@ -191,9 +191,9 @@ export const quizSteps: QuizStep[] = [
   {
     id: 3,
     title: 'Welke kleuren draag jij het liefst?',
-    description: 'Dit gaat over wat jij graag draagt — niet over je huidskleur of ondertoon.',
+    description: 'Dit gaat over wat jij graag draagt — niet over je huidskleur of ondertoon. Meerdere keuzes zijn prima.',
     field: 'neutrals',
-    type: 'radio',
+    type: 'multiselect',
     required: true,
     options: [
       {
@@ -210,6 +210,11 @@ export const quizSteps: QuizStep[] = [
         value: 'neutraal',
         label: 'Neutrale mix',
         description: 'Zwart, wit, grijs — ik combineer graag'
+      },
+      {
+        value: 'mix',
+        label: 'Mix van warm en koel',
+        description: 'Je combineert warme en koele kleuren'
       }
     ]
   },
@@ -450,18 +455,43 @@ export const quizSteps: QuizStep[] = [
   },
   {
     id: 11,
+    title: 'Welke merken spreken jou aan?',
+    description: 'Optioneel — kies merken die je leuk vindt. Dit helpt ons relevantere aanbevelingen te tonen.',
+    field: 'brandPreferences',
+    type: 'multiselect',
+    required: false,
+    options: [
+      { value: 'nike', label: 'Nike' },
+      { value: 'adidas', label: 'Adidas' },
+      { value: 'cos', label: 'COS' },
+      { value: 'arket', label: 'Arket' },
+      { value: 'zara', label: 'Zara' },
+      { value: 'h&m', label: 'H&M' },
+      { value: 'ralph lauren', label: 'Ralph Lauren' },
+      { value: 'tommy hilfiger', label: 'Tommy Hilfiger' },
+      { value: 'hugo boss', label: 'Hugo Boss' },
+      { value: 'massimo dutti', label: 'Massimo Dutti' },
+      { value: 'scotch & soda', label: 'Scotch & Soda' },
+      { value: 'carhartt wip', label: 'Carhartt WIP' },
+      { value: 'acne studios', label: 'Acne Studios' },
+      { value: 'our legacy', label: 'Our Legacy' }
+    ],
+    helperText: 'Je kunt deze stap overslaan als je geen voorkeur hebt'
+  },
+  {
+    id: 12,
     title: 'Wat is jouw budget per kledingstuk?',
-    description: 'We tonen producten die passen bij jouw keuze.',
-    field: 'budgetRange',
-    type: 'slider',
+    description: 'Geef aan binnen welke prijsklasse je zoekt. We tonen producten die passen bij jouw range.',
+    field: 'budget',
+    type: 'budget-range',
     required: true,
-    min: 25,
+    min: 0,
     max: 500,
     step: 25,
     helperText: '€25-75: Budget | €75-150: Middensegment | €150+: Premium'
   },
   {
-    id: 12,
+    id: 13,
     title: 'Wat zijn jouw maten?',
     description: 'Je kunt straks altijd terug en aanpassen.',
     field: 'sizes',
@@ -470,7 +500,7 @@ export const quizSteps: QuizStep[] = [
     helperText: 'Niet zeker? Kies wat je meestal draagt — je kunt dit later aanpassen'
   },
   {
-    id: 13,
+    id: 14,
     title: 'Upload een selfie voor kleurenanalyse',
     description: 'Optioneel. Foto in natuurlijk licht, geen filters. Je kunt deze stap altijd overslaan.',
     field: 'photoUrl',

--- a/src/engine/v2/buildProfile.ts
+++ b/src/engine/v2/buildProfile.ts
@@ -204,8 +204,8 @@ function parseBudget(answers: Record<string, any>): {
     const perItemMax = Math.max(15, explicit.max);
     const perItemMin =
       typeof explicit.min === 'number'
-        ? Math.max(0, explicit.min)
-        : perItemMax * 0.3;
+        ? Math.max(0, Math.min(explicit.min, perItemMax))
+        : 0;
     return {
       perItemMax,
       perItemMin,
@@ -217,11 +217,11 @@ function parseBudget(answers: Record<string, any>): {
   if (slider !== null && slider > 0) {
     return {
       perItemMax: slider,
-      perItemMin: slider * 0.3,
+      perItemMin: 0,
       totalMax: slider * 4,
     };
   }
-  return { perItemMax: 150, perItemMin: 45, totalMax: 600 };
+  return { perItemMax: 150, perItemMin: 0, totalMax: 600 };
 }
 
 function normalizeOccasions(raw: any): OccasionKey[] {
@@ -276,12 +276,42 @@ function normalizeMaterials(raw: any): { preferred: string[]; avoided: string[] 
   return { preferred, avoided: [] };
 }
 
+function normalizeBrands(raw: any): string[] {
+  if (!raw) return [];
+  const arr = Array.isArray(raw) ? raw : [raw];
+  return Array.from(
+    new Set(
+      arr
+        .map((b) => String(b).toLowerCase().trim())
+        .filter(Boolean)
+    )
+  );
+}
+
 function buildColorPreference(answers: Record<string, any>): ColorPreference {
   const cp = answers.colorProfile ?? {};
   const ca = answers.colorAnalysis ?? {};
   const temperature: TemperatureKey | null = (() => {
+    const rawNeutrals = answers.neutrals;
+    const neutralsArr: string[] = Array.isArray(rawNeutrals)
+      ? rawNeutrals
+      : typeof rawNeutrals === 'string' && rawNeutrals.length > 0
+      ? [rawNeutrals]
+      : [];
+
+    // 'mix' (explicit combination) or multiple distinct temperatures
+    // → no single preference, don't penalize either temperature
+    if (neutralsArr.includes('mix')) return null;
+    const distinctTemps = new Set(
+      neutralsArr.filter((v) => v === 'warm' || v === 'koel' || v === 'neutraal')
+    );
+    if (distinctTemps.size > 1) return null;
+
+    const singleTemp = neutralsArr[0];
     const raw =
-      cp.temperature ?? answers.neutrals ?? (ca.undertone === 'warm'
+      cp.temperature ??
+      singleTemp ??
+      (ca.undertone === 'warm'
         ? 'warm'
         : ca.undertone === 'cool'
         ? 'koel'
@@ -451,6 +481,7 @@ export function buildUserStyleProfile(
   const occasions = normalizeOccasions(answers.occasions);
   const goals = normalizeGoals(answers.goals);
   const materials = normalizeMaterials(answers.materials);
+  const preferredBrands = normalizeBrands(answers.brandPreferences);
   const fit = resolveFit(answers.fit);
   const prints = resolvePrints(answers.prints);
   const budget = parseBudget(answers);
@@ -494,6 +525,7 @@ export function buildUserStyleProfile(
     budget,
     occasions,
     goals,
+    preferredBrands,
     sizes:
       answers.sizes && typeof answers.sizes === 'object'
         ? {

--- a/src/engine/v2/candidateFilter.ts
+++ b/src/engine/v2/candidateFilter.ts
@@ -171,6 +171,7 @@ export function filterAndPrepare(
         season: 0,
         prints: 0,
         quality: 0,
+        brand: 0,
       },
       reasons: [],
       formality: enriched.formality,

--- a/src/engine/v2/scoring/brand.ts
+++ b/src/engine/v2/scoring/brand.ts
@@ -1,0 +1,27 @@
+import type { ScoredProduct, UserStyleProfile } from '../types';
+
+export function scoreBrand(
+  product: ScoredProduct,
+  profile: UserStyleProfile
+): { score: number; reason: string } {
+  const prefs = profile.preferredBrands;
+  if (!prefs || prefs.length === 0) {
+    return { score: 0.6, reason: 'no_brand_pref' };
+  }
+
+  const brand = String(product.product.brand ?? '').toLowerCase().trim();
+  if (!brand) return { score: 0.85, reason: 'no_brand_data' };
+
+  const prefSet = new Set(prefs.map((b) => b.toLowerCase().trim()));
+  if (prefSet.has(brand)) {
+    return { score: 1.0, reason: `brand_match(${brand})` };
+  }
+
+  for (const pref of prefSet) {
+    if (brand.includes(pref) || pref.includes(brand)) {
+      return { score: 1.0, reason: `brand_match(${brand})` };
+    }
+  }
+
+  return { score: 0.85, reason: 'brand_neutral' };
+}

--- a/src/engine/v2/scoring/index.ts
+++ b/src/engine/v2/scoring/index.ts
@@ -16,16 +16,18 @@ import { scoreOccasion } from './occasion';
 import { scoreSeason } from './season';
 import { scoreMoodboard } from './moodboard';
 import { scoreQuality } from './quality';
+import { scoreBrand } from './brand';
 
 export const BASE_WEIGHTS: ScoreBreakdown = {
-  archetype: 0.23,
-  color: 0.15,
-  occasion: 0.13,
+  archetype: 0.22,
+  color: 0.14,
+  occasion: 0.12,
   material: 0.09,
-  budget: 0.09,
-  moodboard: 0.08,
+  budget: 0.08,
+  moodboard: 0.07,
   fit: 0.07,
   goals: 0.06,
+  brand: 0.05,
   season: 0.05,
   prints: 0.03,
   quality: 0.02,
@@ -50,6 +52,7 @@ export function computeProductScore(
   const season_ = scoreSeason(product, season);
   const prints = scorePrints(product, profile);
   const quality = scoreQuality(product);
+  const brand = scoreBrand(product, profile);
 
   const breakdown: ScoreBreakdown = {
     archetype: archetype.score,
@@ -63,6 +66,7 @@ export function computeProductScore(
     season: season_.score,
     prints: prints.score,
     quality: quality.score,
+    brand: brand.score,
   };
 
   const weights = BASE_WEIGHTS;
@@ -77,7 +81,8 @@ export function computeProductScore(
     weights.goals * breakdown.goals +
     weights.season * breakdown.season +
     weights.prints * breakdown.prints +
-    weights.quality * breakdown.quality;
+    weights.quality * breakdown.quality +
+    weights.brand * breakdown.brand;
 
   const archetypePenalty =
     archetype.score < 0.2 ? 0.6 : archetype.score < 0.35 ? 0.85 : 1;
@@ -99,5 +104,6 @@ export function computeProductScore(
     season_.reason,
     prints.reason,
     quality.reason,
+    brand.reason,
   ];
 }

--- a/src/engine/v2/types.ts
+++ b/src/engine/v2/types.ts
@@ -69,6 +69,7 @@ export interface UserStyleProfile {
   budget: BudgetProfile;
   occasions: OccasionKey[];
   goals: GoalKey[];
+  preferredBrands: string[];
   sizes: {
     tops?: string;
     bottoms?: string;
@@ -95,6 +96,7 @@ export interface ScoreBreakdown {
   season: number;
   prints: number;
   quality: number;
+  brand: number;
 }
 
 export interface ScoredProduct {

--- a/src/pages/OnboardingFlowPage.tsx
+++ b/src/pages/OnboardingFlowPage.tsx
@@ -28,7 +28,10 @@ type QuizAnswers = {
   baseColors?: string;
   bodyType?: string;
   occasions?: string[];
+  neutrals?: string | string[];
+  budget?: { min: number; max: number };
   budgetRange?: number;
+  brandPreferences?: string[];
   sizes?: any;
   colorAnalysis?: any;
   photoUrl?: string;
@@ -266,6 +269,15 @@ export default function OnboardingFlowPage() {
     if (step.type === 'checkbox' || step.type === 'multiselect') {
       return Array.isArray(answer) && answer.length > 0;
     }
+    if (step.type === 'budget-range') {
+      return (
+        !!answer &&
+        typeof answer === 'object' &&
+        typeof (answer as any).min === 'number' &&
+        typeof (answer as any).max === 'number' &&
+        (answer as any).max >= (answer as any).min
+      );
+    }
     return answer !== undefined && answer !== null && answer !== '';
   };
 
@@ -277,6 +289,18 @@ export default function OnboardingFlowPage() {
     if (step.type === 'checkbox' || step.type === 'multiselect') {
       if (!Array.isArray(answer) || answer.length === 0) {
         return 'Selecteer minimaal één optie om verder te gaan';
+      }
+    } else if (step.type === 'budget-range') {
+      if (
+        !answer ||
+        typeof answer !== 'object' ||
+        typeof (answer as any).min !== 'number' ||
+        typeof (answer as any).max !== 'number'
+      ) {
+        return 'Vul een min en max budget in';
+      }
+      if ((answer as any).max < (answer as any).min) {
+        return 'Max moet groter of gelijk zijn aan min';
       }
     } else {
       if (answer === undefined || answer === null || answer === '') {
@@ -425,7 +449,11 @@ export default function OnboardingFlowPage() {
         photo_url: answers.photoUrl || null,
         quiz_answers: answers,
         sizes: answers.sizes || null,
-        budget_range: answers.budgetRange ? { min: 0, max: answers.budgetRange } : null,
+        budget_range: answers.budget
+          ? answers.budget
+          : answers.budgetRange
+          ? { min: 0, max: answers.budgetRange }
+          : null,
         preferred_occasions: answers.occasions || [],
         completed_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
@@ -788,7 +816,7 @@ export default function OnboardingFlowPage() {
               gender: answers.gender,
               archetype: answers.stylePreferences?.[0] || 'Casual',
               colors: answers.baseColors?.split(',') || [],
-              budgetRange: answers.budgetRange,
+              budgetRange: answers.budget?.max ?? answers.budgetRange,
               occasions: answers.occasions || [],
             }}
           />
@@ -984,7 +1012,95 @@ export default function OnboardingFlowPage() {
               </div>
             )}
 
-            {/* Slider / budget */}
+            {/* Budget range — min + max inputs */}
+            {step.type === 'budget-range' && (() => {
+              const rangeVal = (answers[step.field as keyof QuizAnswers] as { min?: number; max?: number } | undefined) || {};
+              const minVal = typeof rangeVal.min === 'number' ? rangeVal.min : (step.min ?? 0);
+              const maxVal = typeof rangeVal.max === 'number' ? rangeVal.max : 150;
+              const sliderMin = step.min ?? 0;
+              const sliderMax = step.max ?? 500;
+              const stepSize = step.step ?? 25;
+
+              const setRange = (next: { min: number; max: number }) => {
+                const safeMin = Math.max(sliderMin, Math.min(next.min, sliderMax));
+                const safeMax = Math.max(safeMin, Math.min(next.max, sliderMax));
+                handleAnswer(step.field, { min: safeMin, max: safeMax });
+                // Keep legacy field populated for backwards-compatible consumers
+                setAnswers(prev => {
+                  const updated = { ...prev, budget: { min: safeMin, max: safeMax }, budgetRange: safeMax };
+                  autosave(updated, currentStep, phase);
+                  return updated;
+                });
+              };
+
+              const tierLabel = maxVal < 75 ? 'Budget' : maxVal < 150 ? 'Middensegment' : 'Premium';
+
+              return (
+                <div style={{ backgroundColor: 'var(--color-surface)', borderRadius: '16px', border: '1px solid var(--color-border)', padding: '20px' }}>
+                  <div style={{ textAlign: 'center', marginBottom: '20px' }}>
+                    <div style={{ fontSize: '36px', fontWeight: 700, color: 'var(--ff-color-primary-600)', lineHeight: 1.1 }}>
+                      €{minVal} – €{maxVal}
+                    </div>
+                    <div style={{ fontSize: '14px', fontWeight: 500, color: 'var(--color-text)', marginTop: '6px' }}>
+                      {tierLabel}
+                    </div>
+                    <div style={{ fontSize: '12px', color: 'var(--color-muted)', marginTop: '2px' }}>Per kledingstuk</div>
+                  </div>
+
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '16px' }}>
+                    <div>
+                      <label style={{ display: 'block', fontSize: '12px', fontWeight: 600, color: 'var(--color-text)', marginBottom: '6px' }}>Min</label>
+                      <div style={{ position: 'relative' }}>
+                        <span style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--color-muted)', pointerEvents: 'none' }}>€</span>
+                        <input
+                          type="number"
+                          min={sliderMin}
+                          max={sliderMax}
+                          step={stepSize}
+                          value={minVal}
+                          onChange={(e) => {
+                            const v = parseInt(e.target.value, 10);
+                            if (!isNaN(v)) setRange({ min: v, max: maxVal });
+                          }}
+                          style={{ width: '100%', paddingLeft: '24px', paddingRight: '8px', paddingTop: '10px', paddingBottom: '10px', borderRadius: '12px', border: '2px solid var(--color-border)', backgroundColor: 'var(--color-bg)', color: 'var(--color-text)', textAlign: 'center', fontWeight: 700, fontSize: '16px' }}
+                          aria-label="Min budget"
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <label style={{ display: 'block', fontSize: '12px', fontWeight: 600, color: 'var(--color-text)', marginBottom: '6px' }}>Max</label>
+                      <div style={{ position: 'relative' }}>
+                        <span style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--color-muted)', pointerEvents: 'none' }}>€</span>
+                        <input
+                          type="number"
+                          min={sliderMin}
+                          max={sliderMax}
+                          step={stepSize}
+                          value={maxVal}
+                          onChange={(e) => {
+                            const v = parseInt(e.target.value, 10);
+                            if (!isNaN(v)) setRange({ min: minVal, max: v });
+                          }}
+                          style={{ width: '100%', paddingLeft: '24px', paddingRight: '8px', paddingTop: '10px', paddingBottom: '10px', borderRadius: '12px', border: '2px solid var(--color-border)', backgroundColor: 'var(--color-bg)', color: 'var(--color-text)', textAlign: 'center', fontWeight: 700, fontSize: '16px' }}
+                          aria-label="Max budget"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: 'var(--color-muted)' }}>
+                    <span>€{sliderMin} Budget</span>
+                    <span>€75–150 Midden</span>
+                    <span>€{sliderMax}+ Premium</span>
+                  </div>
+                  {step.helperText && (
+                    <p style={{ marginTop: '12px', fontSize: '12px', color: 'var(--color-muted)', textAlign: 'center' }}>{step.helperText}</p>
+                  )}
+                </div>
+              );
+            })()}
+
+            {/* Slider / budget (legacy) */}
             {step.type === 'slider' && (
               <div style={{ backgroundColor: 'var(--color-surface)', borderRadius: '16px', border: '1px solid var(--color-border)', padding: '20px' }}>
                 <div style={{ textAlign: 'center', marginBottom: '20px' }}>
@@ -1205,8 +1321,13 @@ export default function OnboardingFlowPage() {
                   } else if (typeof val === 'number') {
                     displayVal = s.field === 'budgetRange' ? `€${val} per kledingstuk` : String(val);
                   } else if (typeof val === 'object') {
-                    const entries = Object.entries(val as Record<string, string>).filter(([, v]) => v);
-                    displayVal = entries.length > 0 ? entries.map(([, v]) => v).join(' · ') : 'Ingevuld';
+                    if (s.field === 'budget' && typeof (val as any).max === 'number') {
+                      const b = val as { min?: number; max: number };
+                      displayVal = typeof b.min === 'number' ? `€${b.min} – €${b.max} per kledingstuk` : `€${b.max} per kledingstuk`;
+                    } else {
+                      const entries = Object.entries(val as Record<string, string>).filter(([, v]) => v);
+                      displayVal = entries.length > 0 ? entries.map(([, v]) => v).join(' · ') : 'Ingevuld';
+                    }
                   } else {
                     displayVal = String(val);
                   }

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -4,7 +4,10 @@ export interface QuizAnswers {
   baseColors: string;
   bodyType: string;
   occasions: string[];
-  budgetRange: number;
+  neutrals?: string | string[];
+  budget?: { min: number; max: number };
+  budgetRange?: number;
+  brandPreferences?: string[];
   sizes?: {
     tops?: string;
     bottoms?: string;
@@ -23,7 +26,7 @@ export interface QuizStep {
   title: string;
   description: string;
   field: keyof QuizAnswers;
-  type: 'checkbox' | 'radio' | 'select' | 'multiselect' | 'slider' | 'sizes' | 'photo';
+  type: 'checkbox' | 'radio' | 'select' | 'multiselect' | 'slider' | 'budget-range' | 'sizes' | 'photo';
   options?: Array<{
     value: string;
     label: string;


### PR DESCRIPTION
## Summary

Drie UX-verbeteringen in de onboarding-quiz:

### 1. Neutrals (stap 3) — van radio naar multiselect
- Type omgezet naar `multiselect` zodat users meerdere kleurvoorkeuren kunnen kiezen.
- Nieuwe optie `mix` ('Mix van warm en koel') toegevoegd.
- `buildColorPreference` accepteert nu een array; bij `'mix'` of meerdere distinct temperaturen wordt `temperature = null` gezet — geen penalty, scoreColor valt terug op default 0.7.

### 2. Budget (stap 12) — van slider naar min/max range
- Nieuw stap-type `budget-range` met twee number inputs (min / max).
- `answers.budget = { min, max }` is nu de primaire bron; `answers.budgetRange` wordt meegeschreven voor backwards-compat consumers.
- `parseBudget` in de engine gebruikt de echte `min` in plaats van de oude `max * 0.3` fallback.

### 3. Nieuw merkvoorkeur-stap (stap 11) — tussen materials en budget
- Multiselect met 14 populaire merken (Nike, Adidas, COS, Arket, Zara, H&M, Ralph Lauren, Tommy Hilfiger, Hugo Boss, Massimo Dutti, Scotch & Soda, Carhartt WIP, Acne Studios, Our Legacy). Optioneel.
- `UserStyleProfile.preferredBrands: string[]` toegevoegd.
- Nieuwe `scoreBrand` scorer met ~5% weight: 1.0 bij match, 0.85 neutraal, 0.6 als user geen voorkeur opgaf. Andere BASE_WEIGHTS zijn evenredig herschaald (sum blijft 1.00).

## Test plan
- [ ] Quiz doorlopen: stap 3 accepteert meerdere kleurkeuzes inclusief `mix`.
- [ ] Stap 11 (merken) is optioneel — overslaan werkt.
- [ ] Stap 12 (budget) toont min/max inputs; submit slaat `budget: {min, max}` op.
- [ ] Engine v2 build slaagt (`npm run build` ✓).
- [ ] Results blijven relevant voor user die één kleur kiest, en voor user die 'mix' kiest (geen color-penalty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)