### PR TITLE
fix(engine): compositor and filter fixes for minimalist persona

### DIFF
--- a/src/engine/productClassifier.ts
+++ b/src/engine/productClassifier.ts
@@ -221,6 +221,10 @@ const REJECT_REGEX = /\b(pyjama|nachthem|slaappak|ochtendjas|badjas|nightwear|bi
 
 const SPORT_FOOTWEAR_REGEX = /\b(fg|ag|sg|mg|tf|ic|in)\s*[/\\]\s*(fg|ag|sg|mg|tf|ic|in)\b/i;
 
+// Baselayers / thermals are worn under clothing and should never surface in an
+// outfit (e.g. Uniqlo Heattech at €29 was slipping into tops at high min-budget).
+export const BASELAYER_RE = /heattech|baselayer|thermal|ondershirt|\bhemd\b/i;
+
 const KIDS_REGEX = /\b(baby|babies|peuter|kleuter|newborn|infant|kinder|kinderen|junior|kids?|dreumes|toddler|jongens|meisjes|boys|girls|child|children)\b/i;
 
 const MULTIPACK_REGEX = /\b(\d+)[- ]?(pack|stuks)\b/i;
@@ -301,6 +305,9 @@ export function classifyProductDetailed(
   }
   if (SPORT_FOOTWEAR_REGEX.test(nameText)) {
     return { category: 'other', confidence: 'high', signals: [], rejected: true, rejectReason: 'sport footwear studs pattern' };
+  }
+  if (BASELAYER_RE.test(nameText) || BASELAYER_RE.test(descText)) {
+    return { category: 'other', confidence: 'high', signals: [], rejected: true, rejectReason: 'baselayer/thermal — not outfit-visible' };
   }
   if (MULTIPACK_REGEX.test(nameText)) {
     return { category: 'other', confidence: 'high', signals: [], rejected: true, rejectReason: 'multipack' };

--- a/src/engine/v2/candidateFilter.ts
+++ b/src/engine/v2/candidateFilter.ts
@@ -49,11 +49,17 @@ function matchesGender(product: Product, gender: string): boolean {
   return false;
 }
 
-function matchesBudget(product: Product, profile: UserStyleProfile): boolean {
+function budgetCheck(
+  product: Product,
+  profile: UserStyleProfile
+): 'ok' | 'over_budget' | 'below_budget_min' {
   const price = product.price ?? 0;
-  if (price <= 0) return true;
+  if (price <= 0) return 'ok';
   const ceiling = profile.budget.perItemMax * 1.35;
-  return price <= ceiling;
+  if (price > ceiling) return 'over_budget';
+  const min = profile.budget.perItemMin;
+  if (min > 0 && price < min * 0.5) return 'below_budget_min';
+  return 'ok';
 }
 
 function isInStock(product: Product): boolean {
@@ -99,6 +105,7 @@ export function filterAndPrepare(
     non_clothing: 0,
     wrong_gender: 0,
     over_budget: 0,
+    below_budget_min: 0,
     out_of_stock: 0,
     unclassifiable: 0,
     team_sport: 0,
@@ -125,8 +132,9 @@ export function filterAndPrepare(
       byReason.wrong_gender++;
       continue;
     }
-    if (!matchesBudget(product, profile)) {
-      byReason.over_budget++;
+    const budgetStatus = budgetCheck(product, profile);
+    if (budgetStatus !== 'ok') {
+      byReason[budgetStatus]++;
       continue;
     }
 
@@ -188,6 +196,7 @@ export function filterAndPrepare(
     byReason.non_clothing +
     byReason.wrong_gender +
     byReason.over_budget +
+    byReason.below_budget_min +
     byReason.out_of_stock +
     byReason.unclassifiable +
     byReason.team_sport +

--- a/src/engine/v2/coherence.ts
+++ b/src/engine/v2/coherence.ts
@@ -42,6 +42,13 @@ const SPREAD_THRESHOLDS_BY_ARCHETYPE: Partial<Record<ArchetypeKey, SpreadThresho
     mismatchReason: 0.8,
     coherentReason: 0.7,
   },
+  MINIMALIST: {
+    hardPenalty: 0.55,
+    midPenalty: 0.45,
+    softPenalty: 0.35,
+    mismatchReason: 0.4,
+    coherentReason: 0.25,
+  },
 };
 
 function spreadThresholdsFor(profile?: UserStyleProfile): SpreadThresholds {

--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -95,6 +95,24 @@ function pickTopPool(
   return shuffleSeeded(pool, rand);
 }
 
+function workFootwearFloor(profile: UserStyleProfile): number {
+  const relaxed =
+    profile.primaryArchetype === 'STREETWEAR' ||
+    profile.primaryArchetype === 'SMART_CASUAL';
+  return relaxed ? 0.15 : 0.35;
+}
+
+function filterFootwearForOccasion(
+  products: ScoredProduct[],
+  occasion: OccasionKey,
+  profile: UserStyleProfile
+): ScoredProduct[] {
+  if (occasion !== 'work') return products;
+  const floor = workFootwearFloor(profile);
+  const filtered = products.filter((p) => p.formality >= floor);
+  return filtered.length > 0 ? filtered : products;
+}
+
 function brandPenalty(products: ScoredProduct[]): number {
   const brands = products
     .map((p) => (p.product.brand || '').toLowerCase().trim())
@@ -252,8 +270,19 @@ function composeForOccasion(
       picks.bottom = bottomPool[0];
     }
 
-    if (byCategory.footwear.length > 0) {
-      const pool = pickTopPool(byCategory.footwear, targetFormality, poolSize, rand, occasion);
+    const footwearCandidates = filterFootwearForOccasion(
+      byCategory.footwear,
+      occasion,
+      profile
+    );
+    if (footwearCandidates.length > 0) {
+      const pool = pickTopPool(
+        footwearCandidates,
+        targetFormality,
+        poolSize,
+        rand,
+        occasion
+      );
       picks.footwear = pool[0];
     }
 

--- a/src/engine/v2/diversify.ts
+++ b/src/engine/v2/diversify.ts
@@ -53,12 +53,31 @@ export function diversifyOutfits(
   const seenArchetypeSignatures = new Map<string, number>();
   const seenColorSignatures = new Map<string, number>();
   const seenOccasions = new Map<string, number>();
+  const productAppearances = new Map<string, number>();
+
+  const MAX_APPEARANCES = 2;
+
+  const hasOverusedProduct = (cand: OutfitCandidate) =>
+    cand.products.some(
+      (p) => (productAppearances.get(p.product.id) ?? 0) >= MAX_APPEARANCES
+    );
+
+  const registerProducts = (cand: OutfitCandidate) => {
+    for (const p of cand.products) {
+      productAppearances.set(
+        p.product.id,
+        (productAppearances.get(p.product.id) ?? 0) + 1
+      );
+    }
+  };
 
   for (const cand of sorted) {
     if (selected.length >= options.count) break;
 
     const tooSimilar = selected.some((s) => productOverlap(s, cand) > 0.34);
     if (tooSimilar) continue;
+
+    if (hasOverusedProduct(cand)) continue;
 
     const archSig = archetypeSignature(cand);
     const colorSig = colorSignature(cand);
@@ -74,15 +93,18 @@ export function diversifyOutfits(
     seenArchetypeSignatures.set(archSig, archetypeCount + 1);
     seenColorSignatures.set(colorSig, colorCount + 1);
     seenOccasions.set(cand.occasion, occCount + 1);
+    registerProducts(cand);
   }
 
   if (selected.length < options.count) {
     for (const cand of sorted) {
       if (selected.length >= options.count) break;
       if (selected.includes(cand)) continue;
+      if (hasOverusedProduct(cand)) continue;
       const tooSimilar = selected.some((s) => productOverlap(s, cand) > 0.65);
       if (tooSimilar) continue;
       selected.push(cand);
+      registerProducts(cand);
     }
   }
 


### PR DESCRIPTION
## Summary
Five compositor/filter fixes surfaced by minimalist-persona test reports. Each is a small, local change in the engine v2 pipeline — no changes to scoring weights, data loaders, or engine entry points.

## Fixes
1. **Budget-min as hard filter** (`src/engine/v2/candidateFilter.ts`)
   - `perItemMin` was only a scoring penalty, so a €29 Uniqlo Heattech still passed at an €80 min.
   - Added a hard reject: `price < perItemMin * 0.5` → out. Items at 50–100% of min still pass (soft penalty continues to apply in scoring).
   - New `below_budget_min` bucket in the rejection telemetry.

2. **Baselayer detection** (`src/engine/productClassifier.ts`)
   - Added `BASELAYER_RE = /heattech|baselayer|thermal|ondershirt|\bhemd\b/i` and an early reject in `classifyProductDetailed`.
   - Baselayers / thermals never surface as visible tops now.

3. **Footwear-formality floor for work** (`src/engine/v2/composer.ts`)
   - When `occasion === 'work'`, footwear pool is filtered by a formality floor.
   - Archetype-aware: `0.35` default (keeps Vans at 0.21 out of office looks); relaxed to `0.15` when `primaryArchetype` is `STREETWEAR` or `SMART_CASUAL` (those users can wear cleaner sneakers to work).
   - Falls back to the unfiltered pool if the floor leaves nothing, so we never hard-fail to produce an outfit.

4. **Outerwear diversity** (`src/engine/v2/diversify.ts`)
   - `diversifyOutfits` now tracks per-product appearance counts. A candidate is skipped if any of its products is already in 2+ selected outfits.
   - Fixes \"same Linen Overshirt in 3/6 outfits\" — no product can anchor more than two final outfits.

5. **MINIMALIST formality-spread thresholds** (`src/engine/v2/coherence.ts`)
   - Added a `MINIMALIST` entry to `SPREAD_THRESHOLDS_BY_ARCHETYPE` so minimalist outfits enforce tighter formality coherence than the default map (no more streetwear-tee + Suitsupply pantalon combos slipping through).

## Test plan
- [x] `npm run build` passes
- [ ] Run the engine for the minimalist persona (€80 min budget) and confirm: no Heattech / baselayer items, no Vans in work outfits, no single outerwear piece in 3+ outfits, formality spread stays within MINIMALIST thresholds
- [ ] Run for a STREETWEAR persona at work occasion and confirm sneakers (formality ≥ 0.15) still pass
- [ ] Confirm the `below_budget_min` rejection counter appears in engine telemetry for low-priced items

🤖 Generated with [Claude Code](https://claude.com/claude-code)