### PR TITLE
fix(engine/v2): composer outerwear/accessory + off-archetype reject + budget floor

### DIFF
--- a/src/engine/v2/candidateFilter.ts
+++ b/src/engine/v2/candidateFilter.ts
@@ -58,7 +58,7 @@ function budgetCheck(
   const ceiling = profile.budget.perItemMax * 1.35;
   if (price > ceiling) return 'over_budget';
   const min = profile.budget.perItemMin;
-  if (min > 0 && price < min * 0.5) return 'below_budget_min';
+  if (min > 0 && price < min * 0.75) return 'below_budget_min';
   return 'ok';
 }
 

--- a/src/engine/v2/coherence.ts
+++ b/src/engine/v2/coherence.ts
@@ -169,5 +169,16 @@ export function isHardMismatch(
     if (!profileAcceptsAthletic) return true;
   }
 
+  if (profile) {
+    const primaryKey = profile.primaryArchetype;
+    const secondaryKey = profile.secondaryArchetype;
+    for (const p of products) {
+      const primaryFit = p.archetypeFit[primaryKey] ?? 0;
+      if (primaryFit >= 0.15) continue;
+      const secondaryFit = secondaryKey ? (p.archetypeFit[secondaryKey] ?? 0) : 0;
+      if (secondaryFit < 0.25) return true;
+    }
+  }
+
   return false;
 }

--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -29,23 +29,23 @@ const OCCASION_TARGET_FORMALITY: Record<OccasionKey, number> = {
 };
 
 const OCCASION_WANTS_OUTERWEAR: Record<OccasionKey, number> = {
-  work: 0.35,
-  formal: 0.45,
-  casual: 0.2,
-  date: 0.3,
+  work: 0.45,
+  formal: 0.5,
+  casual: 0.25,
+  date: 0.4,
   travel: 0.4,
   sport: 0.05,
-  party: 0.15,
+  party: 0.2,
 };
 
 const OCCASION_WANTS_ACCESSORY: Record<OccasionKey, number> = {
-  work: 0.2,
-  formal: 0.3,
-  casual: 0.15,
-  date: 0.25,
-  travel: 0.1,
+  work: 0.3,
+  formal: 0.4,
+  casual: 0.2,
+  date: 0.35,
+  travel: 0.15,
   sport: 0.0,
-  party: 0.3,
+  party: 0.4,
 };
 
 function seededRandom(seed: number): () => number {
@@ -238,6 +238,9 @@ function composeForOccasion(
 
   for (let attempt = 0; attempt < maxAttempts && candidates.length < count; attempt++) {
     const rand = seededRandom(baseSeed + attempt * 31 + occasion.length);
+    // Independent stream for optional-item dice rolls so shuffle-call depth
+    // can't bias outerwear/accessory inclusion.
+    const auxRand = seededRandom(baseSeed * 7919 + attempt * 41 + occasion.length * 13 + 17);
 
     const useDress =
       allowDress &&
@@ -286,7 +289,7 @@ function composeForOccasion(
       picks.footwear = pool[0];
     }
 
-    if (byCategory.outerwear.length > 0 && rand() < wantOuterwear) {
+    if (byCategory.outerwear.length > 0 && auxRand() < wantOuterwear) {
       const pool = pickTopPool(
         byCategory.outerwear,
         targetFormality,
@@ -297,7 +300,7 @@ function composeForOccasion(
       picks.outerwear = pool[0];
     }
 
-    if (byCategory.accessory.length > 0 && rand() < wantAccessory) {
+    if (byCategory.accessory.length > 0 && auxRand() < wantAccessory) {
       const pool = pickTopPool(
         byCategory.accessory,
         targetFormality,

--- a/src/engine/v2/scoring/budget.ts
+++ b/src/engine/v2/scoring/budget.ts
@@ -15,8 +15,11 @@ export function scoreBudget(
   if (price > max * 1.15) return { score: 0.35, reason: 'over_budget' };
   if (price > max) return { score: 0.6, reason: 'slight_over_budget' };
 
-  if (min > 0 && price < min * 0.5) {
+  if (min > 0 && price < min * 0.75) {
     return { score: 0.55, reason: 'below_min_budget' };
+  }
+  if (min > 0 && price < min) {
+    return { score: 0.7, reason: 'near_min_budget' };
   }
 
   const target = (max + Math.max(min, max * 0.3)) / 2;


### PR DESCRIPTION
## Summary

Drie kritieke fixes in de v2 pipeline: outerwear/accessoires verschijnen weer in outfits, off-archetype items worden geweerd, budget-floor aangescherpt.

### Fix 1 (KRITIEK) — \`src/engine/v2/composer.ts\`
In 30 echte outfits (5 persona's × 6 outfits) verscheen **nulkeer** outerwear of accessory.

**Root cause:** de \`wantOuterwear\` / \`wantAccessory\` dice rolls gebeuren *na* meerdere \`pickTopPool\` → \`shuffleSeeded\` calls die samen ~60 \`rand()\` waarden consumeren per compose-attempt. Op die diepte in de LCG-sequence, gecombineerd met variabele pool-sizes, verschuift de dice-positie in de sequence zonder echt uniform te zamplen. Combinatie met lage baseline-kansen → effectieve kans dicht bij 0.

**Fix:**
- Aparte \`auxRand\` stream gezaaid per attempt (\`baseSeed * 7919 + attempt * 41 + ...\`), volledig onafhankelijk van de shuffle-consumptie.
- Kansen opgehoogd: work 0.35→**0.45**, formal 0.45→**0.5**, date 0.3→**0.4**; accessoires +0.05-0.10 per occasion.

### Fix 2 — \`src/engine/v2/coherence.ts\` (\`isHardMismatch\`)
Off-archetype items lekten door: Tommy Oxford in streetwear-outfits, RL Polo in avant-garde, Carhartt werkbroek in minimalist werk.

**Fix:** nieuwe gate — reject als een product \`primaryFit < 0.15\` EN \`secondaryFit < 0.25\`. \`archetypeFit\` bevat alleen archetypes uit het profile (zie \`scoring/archetype.ts\`), dus deze dubbele check garandeert dat het dominante archetype van het product minstens raakt aan top-1 of top-2 van de gebruiker.

### Fix 3 — \`candidateFilter.ts\` + \`scoring/budget.ts\`
Budget-floor was te genereus: bij \`perItemMin=€80\` kwamen items vanaf €40 erdoor.

**Fix:**
- \`candidateFilter\`: hard reject onder **75%** van \`perItemMin\` (was 50%).
- \`scoreBudget\`: nieuwe \`near_min_budget\` band (75-100% van min → score **0.7**) voor zachte penalty. Onder 75% → \`below_min_budget\` met 0.55.

## Test plan
- [ ] Quiz afronden met work occasion → verwacht ≥30% outfits met blazer/jas
- [ ] Quiz met casual + date → verwacht outerwear in ~25-40% van outfits, accessoires zichtbaar
- [ ] Streetwear profiel → géén Oxford-shirts / preppy polo's meer in resultaten
- [ ] Budget min €80 → géén items onder €60 in outfits; items €60-80 scoren 0.7 niet 1.0
- [ ] \`npm run build\` groen (geverifieerd: ✓ built in 12.38s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)