### PR TITLE
fix(engine): formality filtering, outfit explanation variety, tag allowlist

### DIFF
--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -102,14 +102,72 @@ function workFootwearFloor(profile: UserStyleProfile): number {
   return relaxed ? 0.15 : 0.35;
 }
 
+function workBottomFloor(profile: UserStyleProfile): number {
+  const relaxed =
+    profile.primaryArchetype === 'STREETWEAR' ||
+    profile.primaryArchetype === 'SMART_CASUAL';
+  return relaxed ? 0.25 : 0.4;
+}
+
+const CASUAL_FOOTWEAR_CEILING = 0.7;
+
+const WORK_NEGATIVE_KEYWORDS = [
+  'flannel',
+  'geruit',
+  'check',
+  'plaid',
+  'field',
+  'outdoor',
+];
+
+function hasWorkNegativeKeyword(scored: ScoredProduct): boolean {
+  const p = scored.product;
+  const haystack = [p.name, p.description, p.type]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  if (!haystack) return false;
+  return WORK_NEGATIVE_KEYWORDS.some((kw) => haystack.includes(kw));
+}
+
 function filterFootwearForOccasion(
   products: ScoredProduct[],
   occasion: OccasionKey,
   profile: UserStyleProfile
 ): ScoredProduct[] {
+  if (occasion === 'work') {
+    const floor = workFootwearFloor(profile);
+    const filtered = products.filter((p) => p.formality >= floor);
+    return filtered.length > 0 ? filtered : products;
+  }
+  if (occasion === 'casual') {
+    const filtered = products.filter(
+      (p) => p.formality <= CASUAL_FOOTWEAR_CEILING
+    );
+    return filtered.length > 0 ? filtered : products;
+  }
+  return products;
+}
+
+function filterBottomsForOccasion(
+  products: ScoredProduct[],
+  occasion: OccasionKey,
+  profile: UserStyleProfile
+): ScoredProduct[] {
   if (occasion !== 'work') return products;
-  const floor = workFootwearFloor(profile);
-  const filtered = products.filter((p) => p.formality >= floor);
+  const floor = workBottomFloor(profile);
+  const filtered = products.filter(
+    (p) => p.formality >= floor && !hasWorkNegativeKeyword(p)
+  );
+  return filtered.length > 0 ? filtered : products;
+}
+
+function filterTopsForOccasion(
+  products: ScoredProduct[],
+  occasion: OccasionKey
+): ScoredProduct[] {
+  if (occasion !== 'work') return products;
+  const filtered = products.filter((p) => !hasWorkNegativeKeyword(p));
   return filtered.length > 0 ? filtered : products;
 }
 
@@ -258,9 +316,21 @@ function composeForOccasion(
       const pool = pickTopPool(byCategory.jumpsuit, targetFormality, poolSize, rand, occasion);
       picks.dress = pool[0];
     } else {
-      const topPool = pickTopPool(byCategory.top, targetFormality, poolSize, rand, occasion);
-      const bottomPool = pickTopPool(
+      const topCandidates = filterTopsForOccasion(byCategory.top, occasion);
+      const bottomCandidates = filterBottomsForOccasion(
         byCategory.bottom,
+        occasion,
+        profile
+      );
+      const topPool = pickTopPool(
+        topCandidates,
+        targetFormality,
+        poolSize,
+        rand,
+        occasion
+      );
+      const bottomPool = pickTopPool(
+        bottomCandidates,
         targetFormality,
         poolSize,
         rand,
@@ -357,6 +427,7 @@ export function composeOutfits(
     date: [],
     travel: [],
     sport: [],
+    party: [],
   };
 
   const occasions: OccasionKey[] =

--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -74,17 +74,16 @@ const TEMPERATURE_SENTENCE: Record<TemperatureKey, string> = {
   neutraal: 'Met een neutrale basis.',
 };
 
-function primaryGoalAdjective(goals: GoalKey[]): string | null {
+function primaryGoalAdjective(goals: GoalKey[], index: number): string | null {
   const priority: GoalKey[] = ['timeless', 'professional', 'express', 'minimal'];
   const matched: string[] = [];
   for (const key of priority) {
     if (!goals.includes(key)) continue;
     const adj = GOAL_ADJECTIVE[key];
     if (adj) matched.push(adj);
-    if (matched.length === 2) break;
   }
   if (matched.length === 0) return null;
-  return matched.join(' en ');
+  return matched[index % matched.length];
 }
 
 function matchedPreferredMaterial(
@@ -93,6 +92,7 @@ function matchedPreferredMaterial(
 ): string | null {
   const preferred = profile.materials.preferred.map((m) => m.toLowerCase());
   if (preferred.length === 0) return null;
+  const counts = new Map<string, number>();
   for (const pref of preferred) {
     const aliases = MATERIAL_ALIAS[pref] ?? [pref];
     for (const p of candidate.products) {
@@ -101,24 +101,92 @@ function matchedPreferredMaterial(
         m.toLowerCase()
       );
       if (aliases.some((a) => tags.includes(a) || productMats.includes(a))) {
-        return pref;
+        counts.set(pref, (counts.get(pref) ?? 0) + 1);
       }
     }
   }
-  return null;
+  if (counts.size === 0) return null;
+  return [...counts.entries()].sort(([, a], [, b]) => b - a)[0][0];
+}
+
+function dominantOutfitMaterial(candidate: OutfitCandidate): string | null {
+  const counts = new Map<string, number>();
+  for (const p of candidate.products) {
+    const tags = new Set<string>([
+      ...p.materialTags.map((m) => m.toLowerCase()),
+      ...(p.product.materials ?? []).map((m: string) => m.toLowerCase()),
+    ]);
+    for (const [key, aliases] of Object.entries(MATERIAL_ALIAS)) {
+      if (aliases.some((a) => tags.has(a))) {
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+        break;
+      }
+    }
+  }
+  if (counts.size === 0) return null;
+  const sorted = [...counts.entries()].sort(([, a], [, b]) => b - a);
+  const total = candidate.products.length;
+  const [top1, n1] = sorted[0];
+  if (sorted.length === 1 || n1 / total >= 0.6) return `Volledig in ${top1}`;
+  const [top2] = sorted[1];
+  return `Mix van ${top1} en ${top2}`;
+}
+
+function outfitColorSignal(candidate: OutfitCandidate): string | null {
+  const colors: string[] = [];
+  for (const p of candidate.products) {
+    const first = p.colorTags[0];
+    if (first) colors.push(first.toLowerCase());
+  }
+  if (colors.length === 0) return null;
+  const unique = Array.from(new Set(colors));
+  if (unique.length === 1) return `Monochroom ${unique[0]}`;
+  return `${unique[0]} met ${unique[1]}`;
+}
+
+function outfitLayeringSignal(candidate: OutfitCandidate): string | null {
+  const outer = candidate.products.find((p) => p.category === 'outerwear');
+  if (!outer) return null;
+  const source = (outer.product.type || outer.product.name || 'jas')
+    .toLowerCase()
+    .trim();
+  const label = source.split(/\s+/)[0] || 'jas';
+  return `Gelaagd met ${label}`;
+}
+
+function outfitSpecificSignal(
+  candidate: OutfitCandidate,
+  index: number
+): string | null {
+  const options = [
+    dominantOutfitMaterial(candidate),
+    outfitColorSignal(candidate),
+    outfitLayeringSignal(candidate),
+  ].filter((s): s is string => s !== null);
+  if (options.length === 0) return null;
+  return `${options[index % options.length]}.`;
 }
 
 function buildExplanation(
   candidate: OutfitCandidate,
-  profile: UserStyleProfile
+  profile: UserStyleProfile,
+  index: number
 ): string {
   const signals: string[] = [];
 
-  const goal = primaryGoalAdjective(profile.goals);
+  const goal = primaryGoalAdjective(profile.goals, index);
   if (goal) signals.push(`Afgestemd op je ${goal} stijl.`);
 
+  const outfitSignal = outfitSpecificSignal(candidate, index);
+  if (outfitSignal) signals.push(outfitSignal);
+
   const material = matchedPreferredMaterial(candidate, profile);
-  if (material) signals.push(`Met je voorkeur voor ${material}.`);
+  if (
+    material &&
+    (!outfitSignal || !outfitSignal.toLowerCase().includes(material))
+  ) {
+    signals.push(`Met je voorkeur voor ${material}.`);
+  }
 
   if (profile.color.temperature) {
     signals.push(TEMPERATURE_SENTENCE[profile.color.temperature]);
@@ -179,10 +247,25 @@ function categoryRatio(candidate: OutfitCandidate): {
   return ratio;
 }
 
+const TAG_ALLOW_PREFIXES = [
+  'color_harmony',
+  'style_',
+  'fit_',
+  'brand_match',
+  'occasion_',
+];
+const TAG_DENY_SUBSTRINGS = ['_weak', '_mismatch', '_penalty'];
+
+function isDisplayTag(reason: string): boolean {
+  if (TAG_DENY_SUBSTRINGS.some((s) => reason.includes(s))) return false;
+  return TAG_ALLOW_PREFIXES.some((p) => reason.startsWith(p));
+}
+
 function candidateToOutfit(
   candidate: OutfitCandidate,
   profile: UserStyleProfile,
-  season: Season
+  season: Season,
+  index: number
 ): Outfit {
   const products: Product[] = candidate.products.map((p) => ({
     ...p.product,
@@ -197,6 +280,8 @@ function candidateToOutfit(
     winter: 'winter',
   };
 
+  const displayReasons = candidate.reasons.filter(isDisplayTag).slice(0, 4);
+
   return {
     id: candidate.id,
     title: buildOutfitTitle(candidate, profile),
@@ -209,12 +294,12 @@ function candidateToOutfit(
       new Set([
         profile.primaryArchetype.toLowerCase(),
         candidate.occasion,
-        ...candidate.reasons.slice(0, 4),
+        ...displayReasons,
       ])
     ),
     matchPercentage: buildMatchPercentage(candidate),
     matchScore: buildMatchPercentage(candidate),
-    explanation: buildExplanation(candidate, profile),
+    explanation: buildExplanation(candidate, profile, index),
     season: seasonMap[season],
     structure: candidate.products.map((p) => p.category),
     categoryRatio: categoryRatio(candidate),
@@ -298,7 +383,9 @@ export function runEngineV2(
     excludeIds: Array.from(excludeIds),
   });
 
-  const outfits = diversified.map((c) => candidateToOutfit(c, profile, season));
+  const outfits = diversified.map((c, i) =>
+    candidateToOutfit(c, profile, season, i)
+  );
 
   const occasionsCovered = Array.from(
     new Set(diversified.map((c) => c.occasion))


### PR DESCRIPTION
## Summary

Drie engine v2 fixes op basis van gemelde kwaliteitsproblemen in outfit-output.

### Fix 1 — Formality hard-filter per occasion/categorie (`src/engine/v2/composer.ts`)

Per-occasion scoring rankte wel maar filterde niet: sneakers kwamen door bij werk, field-jassen bij kantoor, oxfords bij casual. Nieuwe filters + negative-keyword lijst:

- **Work**
  - Bottom formality floor **0.40** (relaxed tot 0.25 voor STREETWEAR/SMART_CASUAL)
  - Footwear floor **0.35** (relaxed tot 0.15) — bestaande logica, nu archetype-consistent
  - Title/description/type negative keywords: `flannel`, `geruit`, `check`, `plaid`, `field`, `outdoor` → uitgesloten
- **Casual**
  - Footwear formality ceiling **0.70** — geen formele oxfords meer in casual looks
- Elke filter valt terug op de volle lijst als het resultaat leeg is, zodat we nooit vastlopen op een lege pool
- Meteen meegenomen: `party: []` ontbrak in de `byOccasion`-init (type safety)

### Fix 2 — Explanation varieert per outfit (`src/engine/v2/engine.ts`)

Elk outfit kreeg dezelfde uitleg (zelfde goal-adjectief, zelfde materiaal). Nu rotatie-gestuurd per outfit-index:

- `primaryGoalAdjective(goals, index)` rouleert door gematchte doelen — outfit 1 krijgt "tijdloze", outfit 2 "professionele" wanneer beide goals actief zijn
- Nieuwe `outfitSpecificSignal` bouwt per-outfit content uit drie opties die rouleren:
  - Dominant materiaal: "Volledig in wol" (≥60% dekking) of "Mix van katoen en leer"
  - Kleurcombinatie: "Monochroom zwart" of "navy met camel"
  - Laagopbouw: "Gelaagd met parka" (alleen als outerwear aanwezig)
- `matchedPreferredMaterial` kiest nu het dominante preferred-materiaal in DIT outfit i.p.v. altijd het eerste uit de voorkeurlijst
- Duplicate-check voorkomt dat het outfit-signaal en de materiaalvoorkeur hetzelfde materiaal noemen

### Fix 3 — Diagnostic tags uit UI (`src/engine/v2/engine.ts`)

`candidate.reasons` bevat zowel positieve als negatieve diagnostische signalen (`material_mismatch`, `style_weak`, `_penalty`-varianten). Die lekten naar de UI-tags. Nieuwe allowlist-filter:

- **Allow** prefixes: `color_harmony`, `style_`, `fit_`, `brand_match`, `occasion_`
- **Deny** substrings: `_weak`, `_mismatch`, `_penalty` (overrule allow)

## Test plan
- [x] `npm run build` slaagt
- [ ] Werk-outfits: geen jeans/werkbroeken meer bij CLASSIC/BUSINESS; geen flanel/field-jassen
- [ ] Casual-outfits: geen formele oxfords/derby's; sneakers/loafers blijven
- [ ] STREETWEAR/SMART_CASUAL: werk-looks mogen relaxter (lagere floors werken)
- [ ] Uitleg per outfit: eerste outfit "tijdloze", tweede "professionele" bij multi-goal profielen
- [ ] Outfit-tags bevatten geen `_weak` / `_mismatch` / `_penalty` strings
- [ ] Outfits met outerwear tonen "Gelaagd met …" in één van de uitleggen

🤖 Generated with [Claude Code](https://claude.com/claude-code)