### PR TITLE
fix(engine/v2): brand injection for preferred-brand items (R7)

### DIFF
--- a/src/engine/v2/composer.ts
+++ b/src/engine/v2/composer.ts
@@ -83,16 +83,57 @@ function rankForOccasion(
   });
 }
 
+function buildPreferredBrandSet(profile: UserStyleProfile): Set<string> | null {
+  const prefs = profile.preferredBrands;
+  if (!prefs || prefs.length === 0) return null;
+  const set = new Set(
+    prefs.map((b) => b.toLowerCase().trim()).filter(Boolean)
+  );
+  return set.size > 0 ? set : null;
+}
+
+function isPreferredBrand(
+  product: ScoredProduct,
+  prefSet: Set<string>
+): boolean {
+  const brand = String(product.product.brand ?? '').toLowerCase().trim();
+  if (!brand) return false;
+  if (prefSet.has(brand)) return true;
+  for (const pref of prefSet) {
+    if (brand.includes(pref) || pref.includes(brand)) return true;
+  }
+  return false;
+}
+
 function pickTopPool(
   products: ScoredProduct[],
   targetFormality: number,
   poolSize: number,
   rand: () => number,
-  occasion: OccasionKey
+  occasion: OccasionKey,
+  profile: UserStyleProfile
 ): ScoredProduct[] {
   const ranked = rankForOccasion(products, targetFormality, occasion);
   const pool = ranked.slice(0, Math.max(poolSize, 4));
-  return shuffleSeeded(pool, rand);
+  const shuffled = shuffleSeeded(pool, rand);
+
+  const prefSet = buildPreferredBrandSet(profile);
+  if (!prefSet) return shuffled;
+
+  // Brand injection: if a preferred-brand item is in the top half of the
+  // ranked candidates for this slot, promote the best-ranked one to pool[0]
+  // so the composer actually picks it. Skips when no preferred items are
+  // competitive — we don't force bad matches.
+  const topHalfCount = Math.max(1, Math.ceil(ranked.length / 2));
+  const topHalf = ranked.slice(0, topHalfCount);
+  const bestPreferred = topHalf.find((p) => isPreferredBrand(p, prefSet));
+  if (!bestPreferred) return shuffled;
+
+  if (shuffled[0]?.product.id === bestPreferred.product.id) return shuffled;
+  const rest = shuffled.filter(
+    (p) => p.product.id !== bestPreferred.product.id
+  );
+  return [bestPreferred, ...rest];
 }
 
 function workFootwearFloor(profile: UserStyleProfile): number {
@@ -313,10 +354,10 @@ function composeForOccasion(
 
     let picks: Parameters<typeof tryCompose>[0] = {};
     if (useDress) {
-      const pool = pickTopPool(byCategory.dress, targetFormality, poolSize, rand, occasion);
+      const pool = pickTopPool(byCategory.dress, targetFormality, poolSize, rand, occasion, profile);
       picks.dress = pool[0];
     } else if (useJumpsuit) {
-      const pool = pickTopPool(byCategory.jumpsuit, targetFormality, poolSize, rand, occasion);
+      const pool = pickTopPool(byCategory.jumpsuit, targetFormality, poolSize, rand, occasion, profile);
       picks.dress = pool[0];
     } else {
       const topCandidates = filterTopsForOccasion(byCategory.top, occasion);
@@ -330,14 +371,16 @@ function composeForOccasion(
         targetFormality,
         poolSize,
         rand,
-        occasion
+        occasion,
+        profile
       );
       const bottomPool = pickTopPool(
         bottomCandidates,
         targetFormality,
         poolSize,
         rand,
-        occasion
+        occasion,
+        profile
       );
       picks.top = topPool[0];
       picks.bottom = bottomPool[0];
@@ -354,7 +397,8 @@ function composeForOccasion(
         targetFormality,
         poolSize,
         rand,
-        occasion
+        occasion,
+        profile
       );
       picks.footwear = pool[0];
     }
@@ -365,7 +409,8 @@ function composeForOccasion(
         targetFormality,
         Math.max(3, Math.floor(poolSize / 2)),
         rand,
-        occasion
+        occasion,
+        profile
       );
       picks.outerwear = pool[0];
     }
@@ -376,7 +421,8 @@ function composeForOccasion(
         targetFormality,
         Math.max(3, Math.floor(poolSize / 2)),
         rand,
-        occasion
+        occasion,
+        profile
       );
       picks.accessory = pool[0];
     }

--- a/src/engine/v2/scoring/brand.ts
+++ b/src/engine/v2/scoring/brand.ts
@@ -23,5 +23,5 @@ export function scoreBrand(
     }
   }
 
-  return { score: 0.7, reason: 'brand_neutral' };
+  return { score: 0.55, reason: 'brand_neutral' };
 }


### PR DESCRIPTION
## Summary

R7 sprint fix: guarantee preferred-brand items appear in outfits when the user has explicit brand preferences AND matching items exist in the catalog. Previously brand scoring at weight 10% produced only a 0.03 total-score delta between preferred and neutral brands — too small to overcome archetype/color/occasion signals. Example regression: Sem (avant-garde persona) preferred Acne Studios, catalog had 4 Acne items, yet 0 appeared in his outfits.

- **Composer brand injection** (`composer.ts`): after ranking candidates per slot, `pickTopPool` now promotes the best-ranked preferred-brand item to `pool[0]` whenever one is in the top 50% of the ranked list. If no preferred items are in the pool, it skips silently — we don't force bad matches. Same-brand dupes are still capped by the existing `brandPenalty` multiplier, so outfits naturally land at 1–2 preferred items rather than saturating.
- **Stronger non-match penalty** (`scoring/brand.ts`): non-preferred brand score drops from 0.70 → 0.55 when the user has explicit preferences. Widens the scoring gap so preferred brands also rank better at the ranking step, not just the injection step.
- **Profile flow verified** (`buildProfile.ts`): `normalizeBrands(answers.brandPreferences)` already lowercases, trims, and dedupes into `profile.preferredBrands`, consumed by scoring and now the composer. No change needed.

## Test plan

- [x] `npx vitest run` — 55 pass, 1 pre-existing failure in `productClassifier.test.ts` (prematch-shirt classification, unrelated to brand logic — reproduces on main)
- [ ] Manual: verify Sem persona outfits now include Acne Studios items
- [ ] Manual: verify personas with no brand preferences are unchanged
- [ ] Manual: verify outfits still diversify (brandPenalty caps same-brand dupes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)