### PR TITLE
fix(engine): diversify outfit titles and explanations within user's set

### DIFF
--- a/src/engine/v2/engine.ts
+++ b/src/engine/v2/engine.ts
@@ -3,6 +3,7 @@ import type {
   EngineOptions,
   EngineResult,
   GoalKey,
+  NormalizedCategory,
   OccasionKey,
   OutfitCandidate,
   Season,
@@ -48,19 +49,6 @@ const OCCASION_COPY: Record<OccasionKey, { title: string; description: string }>
   },
 };
 
-function buildOutfitTitle(
-  candidate: OutfitCandidate,
-  profile: UserStyleProfile
-): string {
-  const copy = OCCASION_COPY[candidate.occasion];
-  const archetype = profile.primaryArchetype.toLowerCase().replace('_', ' ');
-  return `${copy.title} · ${archetype}`;
-}
-
-function buildOutfitDescription(candidate: OutfitCandidate): string {
-  return OCCASION_COPY[candidate.occasion].description;
-}
-
 const GOAL_ADJECTIVE: Partial<Record<GoalKey, string>> = {
   timeless: 'tijdloze',
   professional: 'professionele',
@@ -74,6 +62,75 @@ const TEMPERATURE_SENTENCE: Record<TemperatureKey, string> = {
   neutraal: 'Met een neutrale basis.',
 };
 
+const COLOR_LABEL: Record<string, string> = {
+  zwart: 'Zwart',
+  wit: 'Wit',
+  grijs: 'Grijs',
+  navy: 'Navy',
+  camel: 'Camel',
+  denim: 'Denim',
+  contrast: 'Contrast',
+  aardetinten: 'Aardetint',
+  charcoal: 'Charcoal',
+  monochrome: 'Monochroom',
+  blauw: 'Blauw',
+  rood: 'Bordeaux',
+  groen: 'Olijf',
+  bruin: 'Bruin',
+  roze: 'Roze',
+  geel: 'Mosterd',
+  oranje: 'Oranje',
+};
+
+const KEY_PIECE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /blazer|colbert/i, label: 'Blazer' },
+  { pattern: /trenchcoat|trench\b|mantel\b/i, label: 'Trench' },
+  { pattern: /puffer|donsjas/i, label: 'Puffer' },
+  { pattern: /parka/i, label: 'Parka' },
+  { pattern: /bomber/i, label: 'Bomber' },
+  { pattern: /overshirt/i, label: 'Overshirt' },
+  { pattern: /cardigan|vest\b/i, label: 'Cardigan' },
+  { pattern: /trui|sweater|pullover|gebreid|knit/i, label: 'Knit' },
+  { pattern: /overhemd|button-down|dress shirt/i, label: 'Overhemd' },
+  { pattern: /polo/i, label: 'Polo' },
+  { pattern: /hoodie/i, label: 'Hoodie' },
+  { pattern: /chino/i, label: 'Chino' },
+  { pattern: /pantalon/i, label: 'Pantalon' },
+  { pattern: /jeans|spijkerbroek/i, label: 'Jeans' },
+  { pattern: /jurk\b|dress\b/i, label: 'Jurk' },
+  { pattern: /jumpsuit/i, label: 'Jumpsuit' },
+  { pattern: /rok\b|skirt/i, label: 'Rok' },
+  { pattern: /oxford/i, label: 'Oxford' },
+  { pattern: /loafer/i, label: 'Loafers' },
+  { pattern: /chelsea/i, label: 'Chelsea' },
+];
+
+const MATERIAL_LABEL: Record<string, string> = {
+  wol: 'Wollen',
+  merino: 'Merino',
+  katoen: 'Katoenen',
+  linnen: 'Linnen',
+  denim: 'Denim',
+  leer: 'Leren',
+  zijde: 'Zijden',
+  kasjmier: 'Kasjmier',
+  fleece: 'Fleece',
+  tech: 'Tech',
+  canvas: 'Canvas',
+  ribstof: 'Ribstof',
+};
+
+interface DiversityContext {
+  usedTitles: Set<string>;
+  usedExplanationKeys: Set<string>;
+  finalizedExplanations: string[];
+}
+
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 function primaryGoalAdjective(goals: GoalKey[], index: number): string | null {
   const priority: GoalKey[] = ['timeless', 'professional', 'express', 'minimal'];
   const matched: string[] = [];
@@ -84,6 +141,29 @@ function primaryGoalAdjective(goals: GoalKey[], index: number): string | null {
   }
   if (matched.length === 0) return null;
   return matched[index % matched.length];
+}
+
+function materialCounts(candidate: OutfitCandidate): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const p of candidate.products) {
+    const tags = new Set<string>([
+      ...p.materialTags.map((m) => m.toLowerCase()),
+      ...(p.product.materials ?? []).map((m: string) => m.toLowerCase()),
+    ]);
+    for (const [key, aliases] of Object.entries(MATERIAL_ALIAS)) {
+      if (aliases.some((a) => tags.has(a))) {
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+        break;
+      }
+    }
+  }
+  return counts;
+}
+
+function dominantMaterialKey(candidate: OutfitCandidate): string | null {
+  const counts = materialCounts(candidate);
+  if (counts.size === 0) return null;
+  return [...counts.entries()].sort(([, a], [, b]) => b - a)[0][0];
 }
 
 function matchedPreferredMaterial(
@@ -110,19 +190,7 @@ function matchedPreferredMaterial(
 }
 
 function dominantOutfitMaterial(candidate: OutfitCandidate): string | null {
-  const counts = new Map<string, number>();
-  for (const p of candidate.products) {
-    const tags = new Set<string>([
-      ...p.materialTags.map((m) => m.toLowerCase()),
-      ...(p.product.materials ?? []).map((m: string) => m.toLowerCase()),
-    ]);
-    for (const [key, aliases] of Object.entries(MATERIAL_ALIAS)) {
-      if (aliases.some((a) => tags.has(a))) {
-        counts.set(key, (counts.get(key) ?? 0) + 1);
-        break;
-      }
-    }
-  }
+  const counts = materialCounts(candidate);
   if (counts.size === 0) return null;
   const sorted = [...counts.entries()].sort(([, a], [, b]) => b - a);
   const total = candidate.products.length;
@@ -130,6 +198,18 @@ function dominantOutfitMaterial(candidate: OutfitCandidate): string | null {
   if (sorted.length === 1 || n1 / total >= 0.6) return `Volledig in ${top1}`;
   const [top2] = sorted[1];
   return `Mix van ${top1} en ${top2}`;
+}
+
+function dominantOutfitColorKey(candidate: OutfitCandidate): string | null {
+  const counts = new Map<string, number>();
+  for (const p of candidate.products) {
+    for (const tag of p.colorTags) {
+      const key = tag.toLowerCase();
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  if (counts.size === 0) return null;
+  return [...counts.entries()].sort(([, a], [, b]) => b - a)[0][0];
 }
 
 function outfitColorSignal(candidate: OutfitCandidate): string | null {
@@ -167,45 +247,266 @@ function outfitSpecificSignal(
   return `${options[index % options.length]}.`;
 }
 
-function buildExplanation(
+function keyPieceLabel(candidate: OutfitCandidate): string | null {
+  const priority: NormalizedCategory[] = [
+    'outerwear',
+    'dress',
+    'jumpsuit',
+    'top',
+    'bottom',
+    'footwear',
+  ];
+  const items = [...candidate.products].sort((a, b) => {
+    const ia = priority.indexOf(a.category);
+    const ib = priority.indexOf(b.category);
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  });
+  for (const p of items) {
+    const txt = `${p.product.type || ''} ${p.product.name || ''}`;
+    for (const { pattern, label } of KEY_PIECE_PATTERNS) {
+      if (pattern.test(txt)) return label;
+    }
+  }
+  return null;
+}
+
+function dominantOutfitBrand(candidate: OutfitCandidate): string | null {
+  const counts = new Map<string, number>();
+  for (const p of candidate.products) {
+    const brand = (p.product.brand || '').trim();
+    if (!brand) continue;
+    counts.set(brand, (counts.get(brand) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  const sorted = [...counts.entries()].sort(([, a], [, b]) => b - a);
+  const [top, count] = sorted[0];
+  return count >= 2 ? top : null;
+}
+
+function buildOutfitTitle(
+  candidate: OutfitCandidate,
+  profile: UserStyleProfile,
+  index: number,
+  ctx: DiversityContext
+): string {
+  const base = OCCASION_COPY[candidate.occasion].title;
+  const options: string[] = [];
+
+  const colorKey = dominantOutfitColorKey(candidate);
+  if (colorKey) {
+    const label = COLOR_LABEL[colorKey] ?? capitalize(colorKey);
+    options.push(`${base} · ${label}`);
+  }
+
+  const piece = keyPieceLabel(candidate);
+  if (piece) options.push(`${base} · ${piece}`);
+
+  const matKey = dominantMaterialKey(candidate);
+  if (matKey) {
+    const label = MATERIAL_LABEL[matKey] ?? capitalize(matKey);
+    options.push(`${base} · ${label}`);
+  }
+
+  const goal = primaryGoalAdjective(profile.goals, index);
+  if (goal) options.push(`${base} · ${capitalize(goal)}`);
+
+  if (options.length === 0) {
+    const archetype = profile.primaryArchetype.toLowerCase().replace(/_/g, ' ');
+    options.push(`${base} · ${capitalize(archetype)}`);
+  }
+
+  const offset = index % options.length;
+  for (let i = 0; i < options.length; i++) {
+    const title = options[(offset + i) % options.length];
+    if (!ctx.usedTitles.has(title)) {
+      ctx.usedTitles.add(title);
+      return title;
+    }
+  }
+
+  let variant = 2;
+  while (true) {
+    const fallback = `${base} · #${variant}`;
+    if (!ctx.usedTitles.has(fallback)) {
+      ctx.usedTitles.add(fallback);
+      return fallback;
+    }
+    variant++;
+  }
+}
+
+function buildOutfitDescription(candidate: OutfitCandidate): string {
+  return OCCASION_COPY[candidate.occasion].description;
+}
+
+interface ExplanationFragment {
+  key: string;
+  text: string;
+  isGeneric: boolean;
+}
+
+function candidateFragments(
   candidate: OutfitCandidate,
   profile: UserStyleProfile,
   index: number
-): string {
-  const signals: string[] = [];
+): ExplanationFragment[] {
+  const fragments: ExplanationFragment[] = [];
 
   const goal = primaryGoalAdjective(profile.goals, index);
-  if (goal) signals.push(`Afgestemd op je ${goal} stijl.`);
+  if (goal) {
+    fragments.push({
+      key: `goal:${goal}`,
+      text: `Afgestemd op je ${goal} stijl.`,
+      isGeneric: false,
+    });
+  }
 
   const outfitSignal = outfitSpecificSignal(candidate, index);
-  if (outfitSignal) signals.push(outfitSignal);
+  if (outfitSignal) {
+    fragments.push({
+      key: `outfit:${outfitSignal}`,
+      text: outfitSignal,
+      isGeneric: false,
+    });
+  }
+
+  const brand = dominantOutfitBrand(candidate);
+  if (brand) {
+    const preferred = new Set(
+      profile.preferredBrands.map((b) => b.toLowerCase().trim())
+    );
+    const brandLc = brand.toLowerCase();
+    const isPreferred =
+      preferred.has(brandLc) ||
+      [...preferred].some((p) => brandLc.includes(p) || p.includes(brandLc));
+    const text = isPreferred
+      ? `Met ${brand} als voorkeursmerk in de mix.`
+      : `Rond ${brand} opgebouwd.`;
+    fragments.push({ key: `brand:${brand}`, text, isGeneric: false });
+  }
+
+  const piece = keyPieceLabel(candidate);
+  if (piece) {
+    fragments.push({
+      key: `piece:${piece}`,
+      text: `Opgebouwd rond een ${piece.toLowerCase()}.`,
+      isGeneric: false,
+    });
+  }
 
   const material = matchedPreferredMaterial(candidate, profile);
   if (
     material &&
     (!outfitSignal || !outfitSignal.toLowerCase().includes(material))
   ) {
-    signals.push(`Met je voorkeur voor ${material}.`);
+    fragments.push({
+      key: `prefmat:${material}`,
+      text: `Met je voorkeur voor ${material}.`,
+      isGeneric: false,
+    });
   }
 
   if (profile.color.temperature) {
-    signals.push(TEMPERATURE_SENTENCE[profile.color.temperature]);
+    fragments.push({
+      key: `temp:${profile.color.temperature}`,
+      text: TEMPERATURE_SENTENCE[profile.color.temperature],
+      isGeneric: true,
+    });
   }
 
   if (candidate.coherence.completeness >= 1) {
-    signals.push('Compleet van top tot schoen.');
+    fragments.push({
+      key: 'complete',
+      text: 'Compleet van top tot schoen.',
+      isGeneric: true,
+    });
   }
 
   if (profile.moodboard.totalCount >= 10 && profile.moodboard.confidence > 0.5) {
-    signals.push('Gebaseerd op je moodboard-keuzes.');
+    fragments.push({
+      key: 'moodboard',
+      text: 'Gebaseerd op je moodboard-keuzes.',
+      isGeneric: true,
+    });
   }
 
-  if (signals.length === 0) {
-    const primary = profile.primaryArchetype.toLowerCase().replace('_', ' ');
-    return `Afgestemd op je ${primary}-voorkeur.`;
+  return fragments;
+}
+
+function pickFragments(
+  available: ExplanationFragment[],
+  seen: Set<string>,
+  max: number
+): ExplanationFragment[] {
+  const scored = available.map((frag, order) => ({
+    frag,
+    order,
+    seen: seen.has(frag.key) ? 1 : 0,
+    generic: frag.isGeneric ? 1 : 0,
+  }));
+  scored.sort(
+    (a, b) => a.seen - b.seen || a.generic - b.generic || a.order - b.order
+  );
+  return scored.slice(0, max).map((s) => s.frag);
+}
+
+function wordOverlapSimilarity(a: string, b: string): number {
+  const normalize = (s: string) =>
+    new Set(
+      s
+        .toLowerCase()
+        .replace(/[.,·#]/g, ' ')
+        .split(/\s+/)
+        .filter((w) => w.length > 2)
+    );
+  const wa = normalize(a);
+  const wb = normalize(b);
+  if (wa.size === 0 || wb.size === 0) return 0;
+  let shared = 0;
+  for (const w of wa) if (wb.has(w)) shared++;
+  return shared / Math.min(wa.size, wb.size);
+}
+
+function buildExplanation(
+  candidate: OutfitCandidate,
+  profile: UserStyleProfile,
+  index: number,
+  ctx: DiversityContext
+): string {
+  const all = candidateFragments(candidate, profile, index);
+  if (all.length === 0) {
+    const primary = profile.primaryArchetype.toLowerCase().replace(/_/g, ' ');
+    const text = `Afgestemd op je ${primary}-voorkeur.`;
+    ctx.finalizedExplanations.push(text);
+    return text;
   }
 
-  return signals.slice(0, 3).join(' ');
+  const SIM_THRESHOLD = 0.8;
+  let best: { text: string; picked: ExplanationFragment[]; worst: number } = {
+    text: '',
+    picked: [],
+    worst: 1,
+  };
+
+  for (let rotation = 0; rotation < all.length; rotation++) {
+    const rotated = all.slice(rotation).concat(all.slice(0, rotation));
+    const picked = pickFragments(rotated, ctx.usedExplanationKeys, 3);
+    if (picked.length === 0) continue;
+    const text = picked.map((p) => p.text).join(' ');
+    const worst = ctx.finalizedExplanations.reduce(
+      (acc, prev) => Math.max(acc, wordOverlapSimilarity(text, prev)),
+      0
+    );
+    if (worst < SIM_THRESHOLD) {
+      best = { text, picked, worst };
+      break;
+    }
+    if (worst < best.worst) best = { text, picked, worst };
+  }
+
+  for (const p of best.picked) ctx.usedExplanationKeys.add(p.key);
+  ctx.finalizedExplanations.push(best.text);
+  return best.text;
 }
 
 function buildMatchPercentage(candidate: OutfitCandidate): number {
@@ -265,7 +566,8 @@ function candidateToOutfit(
   candidate: OutfitCandidate,
   profile: UserStyleProfile,
   season: Season,
-  index: number
+  index: number,
+  ctx: DiversityContext
 ): Outfit {
   const products: Product[] = candidate.products.map((p) => ({
     ...p.product,
@@ -284,7 +586,7 @@ function candidateToOutfit(
 
   return {
     id: candidate.id,
-    title: buildOutfitTitle(candidate, profile),
+    title: buildOutfitTitle(candidate, profile, index, ctx),
     description: buildOutfitDescription(candidate),
     archetype: profile.primaryArchetype,
     secondaryArchetype: profile.secondaryArchetype ?? undefined,
@@ -299,7 +601,7 @@ function candidateToOutfit(
     ),
     matchPercentage: buildMatchPercentage(candidate),
     matchScore: buildMatchPercentage(candidate),
-    explanation: buildExplanation(candidate, profile, index),
+    explanation: buildExplanation(candidate, profile, index, ctx),
     season: seasonMap[season],
     structure: candidate.products.map((p) => p.category),
     categoryRatio: categoryRatio(candidate),
@@ -383,8 +685,14 @@ export function runEngineV2(
     excludeIds: Array.from(excludeIds),
   });
 
+  const ctx: DiversityContext = {
+    usedTitles: new Set(),
+    usedExplanationKeys: new Set(),
+    finalizedExplanations: [],
+  };
+
   const outfits = diversified.map((c, i) =>
-    candidateToOutfit(c, profile, season, i)
+    candidateToOutfit(c, profile, season, i, ctx)
   );
 
   const occasionsCovered = Array.from(


### PR DESCRIPTION
## Summary
- Outfit titles now include a differentiator (dominant color, key piece, dominant material, or goal adjective) rotated per outfit index, with a global used-title set guaranteeing uniqueness within a user's output (counter fallback as last resort).
- Explanations are built from a typed fragment pool with per-user seen-key tracking — unused, non-generic fragments are preferred first.
- Added a post-hoc word-overlap similarity check (threshold 0.8) that rotates fragment emphasis until divergent, preventing near-duplicate explanations for the same user.
- Added dominant-brand and key-piece fragments so explanations can anchor on outfit-specific signals instead of only generic profile traits (temperature, completeness, moodboard).

## Before / after
Before: two work outfits both titled `Werk-ready · modern minimalist`, both explained `Afgestemd op je tijdloze stijl. In je koele kleurpalet. Compleet van top tot schoen.`
After: `Werk-ready · Navy` + `Werk-ready · Blazer` with distinct fragment combinations per outfit.

## Test plan
- [x] `npx vitest run` — only the pre-existing `productClassifier` "prematch shirt" assertion fails (unchanged from main)
- [x] `npx vite build` — succeeds
- [ ] Manual: generate outfits for each of the 5 test personas, confirm no two titles or explanations repeat per user
- [ ] Manual: verify title/explanation copy stays within the Dutch, non-buzzword CLAUDE.md tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)