### PR TITLE
fix(engine): tighten archetype filter for streetwear + avant-garde

### DIFF
--- a/src/engine/productEnricher.ts
+++ b/src/engine/productEnricher.ts
@@ -1,3 +1,4 @@
+import type { ArchetypeKey } from '@/config/archetypes';
 import type { Product } from './types';
 
 export interface EnrichedSignals {
@@ -133,8 +134,20 @@ function getBrandStyleHint(brand: string): { formality: number; silhouette: stri
   if (ATHLETIC_BRANDS.has(b)) return { formality: 0.10, silhouette: 'slim', archetype: 'athletic' };
   if (BUSINESS_BRANDS.has(b)) return { formality: 0.85, silhouette: 'tailored', archetype: 'business' };
   if (AVANT_GARDE_BRANDS.has(b)) return { formality: 0.40, silhouette: 'draped', archetype: 'avant_garde' };
-  if (CLASSIC_BRANDS.has(b)) return { formality: 0.65, silhouette: 'tailored' };
-  if (MINIMALIST_BRANDS.has(b)) return { formality: 0.55, silhouette: 'clean' };
+  if (CLASSIC_BRANDS.has(b)) return { formality: 0.65, silhouette: 'tailored', archetype: 'classic' };
+  if (MINIMALIST_BRANDS.has(b)) return { formality: 0.55, silhouette: 'clean', archetype: 'minimalist' };
+  return null;
+}
+
+export function getBrandArchetype(brand: string): ArchetypeKey | null {
+  const b = (brand || '').toLowerCase().trim();
+  if (!b) return null;
+  if (STREETWEAR_BRANDS.has(b)) return 'STREETWEAR';
+  if (ATHLETIC_BRANDS.has(b)) return 'ATHLETIC';
+  if (BUSINESS_BRANDS.has(b)) return 'BUSINESS';
+  if (AVANT_GARDE_BRANDS.has(b)) return 'AVANT_GARDE';
+  if (CLASSIC_BRANDS.has(b)) return 'CLASSIC';
+  if (MINIMALIST_BRANDS.has(b)) return 'MINIMALIST';
   return null;
 }
 

--- a/src/engine/v2/candidateFilter.ts
+++ b/src/engine/v2/candidateFilter.ts
@@ -1,6 +1,6 @@
 import type { Product } from '../types';
 import { classifyProduct } from '../productClassifier';
-import { deriveAthleticIntent, enrichProduct, TEAM_SPORT_RE } from '../productEnricher';
+import { deriveAthleticIntent, enrichProduct, getBrandArchetype, TEAM_SPORT_RE } from '../productEnricher';
 import type {
   NormalizedCategory,
   ScoredProduct,
@@ -110,6 +110,7 @@ export function filterAndPrepare(
     unclassifiable: 0,
     team_sport: 0,
     athletic_mismatch: 0,
+    archetype_mismatch: 0,
   };
   const acceptsAthletic = profileAcceptsAthletic(profile);
   const byCategory: Record<NormalizedCategory, ScoredProduct[]> = {
@@ -163,6 +164,20 @@ export function filterAndPrepare(
     }
 
     const enriched = enrichProduct(product);
+
+    if (profile.primaryArchetype === 'STREETWEAR' && enriched.formality > 0.50) {
+      byReason.archetype_mismatch++;
+      continue;
+    }
+
+    if (profile.primaryArchetype === 'AVANT_GARDE') {
+      const productArchetype = getBrandArchetype(product.brand ?? '');
+      if (productArchetype === 'MINIMALIST' || productArchetype === 'CLASSIC') {
+        byReason.archetype_mismatch++;
+        continue;
+      }
+    }
+
     const scored: ScoredProduct = {
       product: { ...product, category: cat, formality: enriched.formality },
       category: cat,
@@ -200,7 +215,8 @@ export function filterAndPrepare(
     byReason.out_of_stock +
     byReason.unclassifiable +
     byReason.team_sport +
-    byReason.athletic_mismatch;
+    byReason.athletic_mismatch +
+    byReason.archetype_mismatch;
 
   return {
     candidates,

--- a/src/engine/v2/coherence.ts
+++ b/src/engine/v2/coherence.ts
@@ -51,6 +51,21 @@ const SPREAD_THRESHOLDS_BY_ARCHETYPE: Partial<Record<ArchetypeKey, SpreadThresho
   },
 };
 
+interface HardMismatchThresholds {
+  primary: number;
+  secondary: number;
+}
+
+const DEFAULT_HARD_MISMATCH: HardMismatchThresholds = {
+  primary: 0.15,
+  secondary: 0.25,
+};
+
+const HARD_MISMATCH_BY_ARCHETYPE: Partial<Record<ArchetypeKey, HardMismatchThresholds>> = {
+  STREETWEAR: { primary: 0.25, secondary: 0.35 },
+  AVANT_GARDE: { primary: 0.25, secondary: 0.35 },
+};
+
 function spreadThresholdsFor(profile?: UserStyleProfile): SpreadThresholds {
   if (!profile) return DEFAULT_SPREAD_THRESHOLDS;
   return (
@@ -172,11 +187,13 @@ export function isHardMismatch(
   if (profile) {
     const primaryKey = profile.primaryArchetype;
     const secondaryKey = profile.secondaryArchetype;
+    const thresh =
+      HARD_MISMATCH_BY_ARCHETYPE[primaryKey] ?? DEFAULT_HARD_MISMATCH;
     for (const p of products) {
       const primaryFit = p.archetypeFit[primaryKey] ?? 0;
-      if (primaryFit >= 0.15) continue;
+      if (primaryFit >= thresh.primary) continue;
       const secondaryFit = secondaryKey ? (p.archetypeFit[secondaryKey] ?? 0) : 0;
-      if (secondaryFit < 0.25) return true;
+      if (secondaryFit < thresh.secondary) return true;
     }
   }
 

--- a/src/engine/v2/scoring/brand.ts
+++ b/src/engine/v2/scoring/brand.ts
@@ -1,15 +1,54 @@
+import type { ArchetypeKey } from '@/config/archetypes';
 import type { ScoredProduct, UserStyleProfile } from '../types';
+
+const NEGATIVE_BRANDS_BY_ARCHETYPE: Partial<Record<ArchetypeKey, Set<string>>> = {
+  STREETWEAR: new Set([
+    'ralph lauren', 'polo ralph lauren', 'tommy hilfiger',
+    'lacoste', 'gant', 'hugo boss', 'boss', 'massimo dutti',
+    'suitsupply', 'hackett', 'charles tyrwhitt', 'brooks brothers',
+    'ermenegildo zegna', 'zegna', 'canali', 'corneliani',
+  ]),
+  AVANT_GARDE: new Set([
+    'cos', 'arket', 'uniqlo', 'muji', 'everlane', 'filippa k',
+    'ralph lauren', 'polo ralph lauren', 'tommy hilfiger',
+    'lacoste', 'gant', 'hugo boss', 'boss', 'massimo dutti',
+    'suitsupply', 'hackett',
+  ]),
+  MINIMALIST: new Set([
+    'stussy', 'stüssy', 'supreme', 'palace', 'off-white', 'huf', 'obey',
+  ]),
+  CLASSIC: new Set([
+    'stussy', 'stüssy', 'supreme', 'palace', 'off-white',
+    'rick owens', 'yohji yamamoto', 'comme des garcons', 'comme des garçons',
+    'vetements', 'julius',
+  ]),
+};
+
+function isNegativeBrand(brand: string, primary: ArchetypeKey): boolean {
+  const set = NEGATIVE_BRANDS_BY_ARCHETYPE[primary];
+  if (!set) return false;
+  if (set.has(brand)) return true;
+  for (const n of set) {
+    if (brand.includes(n) || n.includes(brand)) return true;
+  }
+  return false;
+}
 
 export function scoreBrand(
   product: ScoredProduct,
   profile: UserStyleProfile
 ): { score: number; reason: string } {
+  const brand = String(product.product.brand ?? '').toLowerCase().trim();
+
+  if (brand && isNegativeBrand(brand, profile.primaryArchetype)) {
+    return { score: 0.25, reason: `brand_off_archetype(${brand})` };
+  }
+
   const prefs = profile.preferredBrands;
   if (!prefs || prefs.length === 0) {
     return { score: 1.0, reason: 'no_brand_pref' };
   }
 
-  const brand = String(product.product.brand ?? '').toLowerCase().trim();
   if (!brand) return { score: 0.85, reason: 'no_brand_data' };
 
   const prefSet = new Set(prefs.map((b) => b.toLowerCase().trim()));


### PR DESCRIPTION
## Summary
Off-archetype items (Tommy Hilfiger chinos in streetwear outfits, COS in avant-garde) leaked through the R6 formality hard-filter. This PR tightens the archetype guard at three layers so they stop reaching the composer.

- **`coherence.ts` — per-archetype `isHardMismatch` thresholds.** STREETWEAR and AVANT_GARDE now reject a candidate outfit product when `primaryFit < 0.25` AND `secondaryFit < 0.35` (default stays 0.15 / 0.25).
- **`candidateFilter.ts` — archetype-specific pre-scoring rejects.** STREETWEAR drops items with `formality > 0.50` (catches chinos @ 0.55, pantalons @ 0.70, overhemden, blazers, pak). AVANT_GARDE drops items whose brand maps to MINIMALIST or CLASSIC via the new `getBrandArchetype` helper.
- **`productEnricher.ts` — `getBrandArchetype` exported.** Also adds `archetype` field to MINIMALIST/CLASSIC brand hints (COS was already in `MINIMALIST_BRANDS`; no leakage into AG).
- **`scoring/brand.ts` — negative-brand list per archetype.** Off-archetype brands score `0.25` instead of the `0.7` neutral default so the coherence guard downstream gets the right signal even for items that squeeze past filters.

## Test plan
- [x] `npx vitest run` → 55 passing. 1 pre-existing failure in `productClassifier.test.ts` (Nike prematch shirt misclassified as `other`) reproduces on base — not caused by this PR.
- [ ] Re-run the 5-persona benchmark and confirm STREETWEAR + AVANT_GARDE archetype scores move toward 9/10.
- [ ] Spot-check a STREETWEAR result set: no chinos, pantalons, blazers.
- [ ] Spot-check an AVANT_GARDE result set: no Tommy / Ralph Lauren / COS / Arket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)