### PR TITLE
fix(engine/v2): strengthen diversify — stop product re-use across outfits

### DIFF
--- a/src/engine/v2/diversify.ts
+++ b/src/engine/v2/diversify.ts
@@ -1,10 +1,16 @@
-import type { OutfitCandidate } from './types';
+import type { NormalizedCategory, OutfitCandidate, ScoredProduct } from './types';
 
 export interface DiversifyOptions {
   count: number;
   occasionBalance: boolean;
   excludeIds?: string[];
 }
+
+const OVERLAP_HARD_THRESHOLD = 0.25;
+const OVERLAP_FALLBACK_THRESHOLD = 0.65;
+const REUSE_PENALTY_PER_PRODUCT = 0.15;
+const SLOT_COLLISION_PENALTY = 0.2;
+const SLOT_CATEGORIES: NormalizedCategory[] = ['footwear', 'bottom', 'outerwear'];
 
 function productOverlap(a: OutfitCandidate, b: OutfitCandidate): number {
   const aIds = new Set(a.products.map((p) => p.product.id));
@@ -35,11 +41,21 @@ function colorSignature(candidate: OutfitCandidate): string {
   return Array.from(colors).sort().slice(0, 3).join(',');
 }
 
-function uniqueOuterwearPoolSize(candidates: OutfitCandidate[]): number {
+function productsByCategory(
+  candidate: OutfitCandidate,
+  category: NormalizedCategory
+): ScoredProduct[] {
+  return candidate.products.filter((p) => p.category === category);
+}
+
+function countUniqueProductsInCategory(
+  pool: OutfitCandidate[],
+  category: NormalizedCategory
+): number {
   const ids = new Set<string>();
-  for (const cand of candidates) {
+  for (const cand of pool) {
     for (const p of cand.products) {
-      if (p.category === 'outerwear') ids.add(p.product.id);
+      if (p.category === category) ids.add(p.product.id);
     }
   }
   return ids.size;
@@ -55,88 +71,150 @@ export function diversifyOutfits(
   );
   if (pool.length === 0) return [];
 
-  const sorted = [...pool].sort(
-    (a, b) => b.compositionScore - a.compositionScore
-  );
+  // Dynamic appearance cap: if pool is large relative to target count,
+  // enforce a unique-products-per-outfit rule (cap=1). Otherwise allow up to 2.
+  const MAX_APPEARANCES = pool.length >= options.count * 3 ? 1 : 2;
+
+  // Footwear diversity: if the pool has at least 3 unique footwear items,
+  // the same shoe may not appear in two selected outfits.
+  const uniqueFootwearInPool = countUniqueProductsInCategory(pool, 'footwear');
+  const strictFootwearDiversity = uniqueFootwearInPool >= 3;
 
   const selected: OutfitCandidate[] = [];
   const seenArchetypeSignatures = new Map<string, number>();
   const seenColorSignatures = new Map<string, number>();
   const seenOccasions = new Map<string, number>();
   const productAppearances = new Map<string, number>();
-  const usedAccessoryIds = new Set<string>();
-  const usedOuterwearIds = new Set<string>();
+  const usedProductIds = new Set<string>();
+  const usedFootwearIds = new Set<string>();
 
-  const MAX_APPEARANCES = 2;
-  const outerwearPoolSize = uniqueOuterwearPoolSize(pool);
-  const enforceOuterwearUniqueness = outerwearPoolSize > 3;
+  const appearanceCount = (id: string) => productAppearances.get(id) ?? 0;
 
-  const hasOverusedProduct = (cand: OutfitCandidate) =>
-    cand.products.some(
-      (p) => (productAppearances.get(p.product.id) ?? 0) >= MAX_APPEARANCES
-    );
-
-  const getAccessories = (cand: OutfitCandidate) =>
-    cand.products.filter((p) => p.category === 'accessory');
-  const getOuterwear = (cand: OutfitCandidate) =>
-    cand.products.filter((p) => p.category === 'outerwear');
-
-  const hasRepeatAccessory = (cand: OutfitCandidate) =>
-    getAccessories(cand).some((p) => usedAccessoryIds.has(p.product.id));
-  const hasRepeatOuterwear = (cand: OutfitCandidate) =>
-    enforceOuterwearUniqueness &&
-    getOuterwear(cand).some((p) => usedOuterwearIds.has(p.product.id));
+  const hasOverusedProduct = (cand: OutfitCandidate, cap: number) =>
+    cand.products.some((p) => appearanceCount(p.product.id) >= cap);
 
   const registerProducts = (cand: OutfitCandidate) => {
     for (const p of cand.products) {
-      productAppearances.set(
-        p.product.id,
-        (productAppearances.get(p.product.id) ?? 0) + 1
-      );
-    }
-    for (const p of getAccessories(cand)) {
-      usedAccessoryIds.add(p.product.id);
-    }
-    for (const p of getOuterwear(cand)) {
-      usedOuterwearIds.add(p.product.id);
+      productAppearances.set(p.product.id, appearanceCount(p.product.id) + 1);
+      usedProductIds.add(p.product.id);
+      if (p.category === 'footwear') usedFootwearIds.add(p.product.id);
     }
   };
 
-  for (const cand of sorted) {
-    if (selected.length >= options.count) break;
+  const slotCollisionPenalty = (cand: OutfitCandidate): number => {
+    if (selected.length === 0) return 0;
+    let penalty = 0;
+    for (const category of SLOT_CATEGORIES) {
+      const candItems = productsByCategory(cand, category);
+      if (candItems.length === 0) continue;
+      const candIds = new Set(candItems.map((p) => p.product.id));
+      for (const s of selected) {
+        const selectedItems = productsByCategory(s, category);
+        const collides = selectedItems.some((p) => candIds.has(p.product.id));
+        if (collides) {
+          penalty += SLOT_COLLISION_PENALTY;
+          break; // one collision per category is enough
+        }
+      }
+    }
+    return penalty;
+  };
 
-    const tooSimilar = selected.some((s) => productOverlap(s, cand) > 0.34);
-    if (tooSimilar) continue;
+  const reusePenalty = (cand: OutfitCandidate): number => {
+    let reused = 0;
+    for (const p of cand.products) {
+      if (usedProductIds.has(p.product.id)) reused++;
+    }
+    return reused * REUSE_PENALTY_PER_PRODUCT;
+  };
 
-    if (hasOverusedProduct(cand)) continue;
-    if (hasRepeatAccessory(cand)) continue;
-    if (hasRepeatOuterwear(cand)) continue;
+  const violatesFootwear = (cand: OutfitCandidate): boolean => {
+    if (!strictFootwearDiversity) return false;
+    return productsByCategory(cand, 'footwear').some((p) =>
+      usedFootwearIds.has(p.product.id)
+    );
+  };
 
-    const archSig = archetypeSignature(cand);
-    const colorSig = colorSignature(cand);
-    const archetypeCount = seenArchetypeSignatures.get(archSig) ?? 0;
-    const colorCount = seenColorSignatures.get(colorSig) ?? 0;
-    const occCount = seenOccasions.get(cand.occasion) ?? 0;
+  const passesHardConstraints = (
+    cand: OutfitCandidate,
+    cap: number,
+    overlapThreshold: number
+  ): boolean => {
+    if (selected.includes(cand)) return false;
+    if (hasOverusedProduct(cand, cap)) return false;
+    if (violatesFootwear(cand)) return false;
+    if (selected.some((s) => productOverlap(s, cand) > overlapThreshold))
+      return false;
+    return true;
+  };
 
-    if (archetypeCount >= 2) continue;
-    if (colorCount >= 2) continue;
-    if (options.occasionBalance && occCount >= 2) continue;
+  // Greedy selection with dynamic re-scoring so previously-chosen outfits
+  // influence the ranking of remaining candidates.
+  while (selected.length < options.count) {
+    let best: OutfitCandidate | null = null;
+    let bestScore = -Infinity;
+    let bestArch = '';
+    let bestColor = '';
 
-    selected.push(cand);
-    seenArchetypeSignatures.set(archSig, archetypeCount + 1);
-    seenColorSignatures.set(colorSig, colorCount + 1);
-    seenOccasions.set(cand.occasion, occCount + 1);
-    registerProducts(cand);
+    for (const cand of pool) {
+      if (!passesHardConstraints(cand, MAX_APPEARANCES, OVERLAP_HARD_THRESHOLD))
+        continue;
+
+      const archSig = archetypeSignature(cand);
+      const colorSig = colorSignature(cand);
+      if ((seenArchetypeSignatures.get(archSig) ?? 0) >= 2) continue;
+      if ((seenColorSignatures.get(colorSig) ?? 0) >= 2) continue;
+      if (
+        options.occasionBalance &&
+        (seenOccasions.get(cand.occasion) ?? 0) >= 2
+      )
+        continue;
+
+      const effective =
+        cand.compositionScore - reusePenalty(cand) - slotCollisionPenalty(cand);
+
+      if (effective > bestScore) {
+        best = cand;
+        bestScore = effective;
+        bestArch = archSig;
+        bestColor = colorSig;
+      }
+    }
+
+    if (!best) break;
+
+    selected.push(best);
+    seenArchetypeSignatures.set(
+      bestArch,
+      (seenArchetypeSignatures.get(bestArch) ?? 0) + 1
+    );
+    seenColorSignatures.set(
+      bestColor,
+      (seenColorSignatures.get(bestColor) ?? 0) + 1
+    );
+    seenOccasions.set(
+      best.occasion,
+      (seenOccasions.get(best.occasion) ?? 0) + 1
+    );
+    registerProducts(best);
   }
 
+  // Fallback: if we still need outfits, relax saturation + overlap rules,
+  // but keep the appearance cap and footwear diversity rule in place.
   if (selected.length < options.count) {
-    for (const cand of sorted) {
+    const sortedByScore = [...pool].sort(
+      (a, b) => b.compositionScore - a.compositionScore
+    );
+    for (const cand of sortedByScore) {
       if (selected.length >= options.count) break;
-      if (selected.includes(cand)) continue;
-      if (hasOverusedProduct(cand)) continue;
-      if (hasRepeatOuterwear(cand)) continue;
-      const tooSimilar = selected.some((s) => productOverlap(s, cand) > 0.65);
-      if (tooSimilar) continue;
+      if (
+        !passesHardConstraints(
+          cand,
+          MAX_APPEARANCES,
+          OVERLAP_FALLBACK_THRESHOLD
+        )
+      )
+        continue;
       selected.push(cand);
       registerProducts(cand);
     }


### PR DESCRIPTION
## Summary
- Stronger product appearance cap: unique-per-outfit when pool ≥ `count × 3`, else max 2
- Tightened overlap threshold `0.34 → 0.25` and added greedy re-scoring so each pick influences the next
- Reuse penalty (-0.15 per already-used product) + per-slot collision penalty (-0.20 for footwear/bottom/outerwear reuse)
- Hard footwear-uniqueness rule when the pool has ≥3 unique footwear items

## Why
R7 data showed the same products appearing twice across outfits (Thomas: Clarks desert boot 2×, RL chino 2×; Jayden: Nike Tech Fleece 2×, Levi's 568 2×, Nike ACG 2×; Pieter: Clarks 2×, Gant crewneck 2×, MOP trench 2×, Stan Smith 2×; Sem: Stone Island 2×, Lemaire trousers 2×). Diversity score averaged 5/10. The new rules score candidates against already-selected outfits so reuse is actively penalized, and the appearance cap enforces uniqueness whenever the pool is large enough to support it.

## Test plan
- [x] `npx vitest run` — 55/56 pass (1 pre-existing unrelated failure in `productClassifier.test.ts`, same on `main`)
- [x] `npm run build` — green
- [ ] Persona regression run (Thomas, Jayden, Pieter, Sem) — verify no product appears in >1 outfit and diversity score rises above R7 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)