### PR TITLE
Add LICENSE, link langgraph port, ignore per-developer state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,7 @@ desktop.ini
 *.bak
 *.backup
 *.old
+
+# Claude Code per-project state and vault references
+.claude/
+CLAUDE-vault.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Luc van Dokkum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ Production builds run on Netlify. Vite produces a static site; runtime work happ
 - [`docs/DESIGN_SYSTEM_QUICK_REFERENCE.md`](docs/DESIGN_SYSTEM_QUICK_REFERENCE.md) — Design tokens and component classes.
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — End-to-end pipeline, signals, what runs client-side vs in edge functions, trade-offs.
 - [`docs/TERMINOLOGY_CONSISTENCY_GUIDE.md`](docs/TERMINOLOGY_CONSISTENCY_GUIDE.md) — Terminology conventions across marketing and product surfaces.
+
+## Related
+
+- [**fitfi-recommender-langgraph**](https://github.com/lucavandee/fitfi-recommender-langgraph) — Python LangGraph port of this repo's recommendation pipeline, with an eval suite. Built as a framework-learning exercise; not a replacement for the production engine.


### PR DESCRIPTION
## Summary

Three small repo-hygiene additions:

- **LICENSE**: MIT, 2026, Luc van Dokkum. No license file existed; this makes the terms explicit for anyone reading or forking.
- **README cross-link**: a new "Related" section points to [lucavandee/fitfi-recommender-langgraph](https://github.com/lucavandee/fitfi-recommender-langgraph), the Python LangGraph port of this repo's recommendation pipeline. Closes the narrative loop for a reader who lands here first.
- **.gitignore**: adds `.claude/` and `CLAUDE-vault.md`. Both are per-developer state that should not be tracked.

Doc + meta only. No code, schema, or config changed.

## Test plan

- [ ] [LICENSE](LICENSE) renders on the repo landing page.
- [ ] README "Related" link resolves to the langgraph repo.
- [ ] After merge, `git status` in the working tree no longer shows `.claude/` or `CLAUDE-vault.md` as untracked.
- [ ] CI passes (doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)