### PR TITLE
fix(quiz): quiz completion crash (missing Spinner import) + TDZ in handleSubmit

### DIFF
--- a/src/components/quiz/CalibrationStep.tsx
+++ b/src/components/quiz/CalibrationStep.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { OutfitCalibrationCard } from './OutfitCalibrationCard';
 import { Sparkles, ArrowRight, CheckCircle2, TrendingUp } from 'lucide-react';
+import { Spinner } from '@/components/ui/Spinner';
 import { useUser } from '@/context/UserContext';
 import { CalibrationService } from '@/services/visualPreferences/calibrationService';
 import { CalibrationBridge } from '@/services/calibration/calibrationBridge';

--- a/src/components/quiz/__tests__/CalibrationStep.render.test.tsx
+++ b/src/components/quiz/__tests__/CalibrationStep.render.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Regressietest voor de quiz-completion crash (prod, juni 2026).
+ *
+ * Repro: na de swipe-fase klikt de gebruiker "Bekijk de outfits" in de
+ * PhaseTransition, waarna OnboardingFlowPage CalibrationStep mount met
+ * loading=true. De loading-branch rendert <Spinner />; als die import
+ * ontbreekt gooit React een ReferenceError ("Spinner is not defined")
+ * tijdens render en vangt de ErrorBoundary de hele pagina af. De quiz
+ * kan dan door niemand worden afgerond.
+ *
+ * Deze test rendert de component server-side (node env, geen jsdom nodig):
+ * effects draaien niet, dus we raken exact de initiële loading-branch.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+vi.mock('@/context/UserContext', () => ({
+  useUser: () => ({ user: null }),
+}));
+
+vi.mock('@/services/visualPreferences/calibrationService', () => ({
+  CalibrationService: {},
+}));
+
+vi.mock('@/services/calibration/calibrationBridge', () => ({
+  CalibrationBridge: {},
+}));
+
+vi.mock('@/services/visualPreferences/visualPreferenceService', () => ({
+  VisualPreferenceService: {},
+}));
+
+vi.mock('../OutfitCalibrationCard', () => ({
+  OutfitCalibrationCard: () => null,
+}));
+
+import { CalibrationStep } from '../CalibrationStep';
+
+describe('CalibrationStep initial render (loading state)', () => {
+  it('rendert de loading-spinner zonder te crashen', () => {
+    let html = '';
+    expect(() => {
+      html = renderToString(
+        <CalibrationStep sessionId="test-session" onComplete={() => {}} />
+      );
+    }).not.toThrow();
+
+    expect(html).toContain('Outfits voorbereiden');
+  });
+});

--- a/src/pages/OnboardingFlowPage.tsx
+++ b/src/pages/OnboardingFlowPage.tsx
@@ -583,7 +583,7 @@ export default function OnboardingFlowPage() {
       localStorage.setItem(LS_KEYS.QUIZ_COMPLETED, "1");
       localStorage.removeItem('ff_quiz_step');
       localStorage.setItem('ff_session_id', sessionId);
-      if (user?.id) clearProgressFromSupabase(user.id);
+      if (userId) clearProgressFromSupabase(userId);
 
       // client and userId already declared above
       let syncSuccess = false;


### PR DESCRIPTION
## Probleem

Op productie crasht de stijlquiz voor iedereen: na de swipe-fase en de celebration-overlay toont de knop "Bekijk de outfits" de generieke ErrorBoundary. `handleSubmit` draait nooit, `ff_quiz_completed` wordt nooit gezet, en /results (achter RequireQuiz) is onbereikbaar.

## Root cause (bewezen)

**Bug 1, de crash:** `src/components/quiz/CalibrationStep.tsx` gebruikt `<Spinner />` (loading-branch en applying-branch) zonder import. Commit `2161127a` verving de inline spinner-div door `<Spinner />` maar voegde de import nooit toe. CalibrationStep mount met `loading=true`, dus de allereerste render van de calibration-fase gooit `ReferenceError: Spinner is not defined` en de ErrorBoundary vangt de pagina af. `vite build` typecheckt niet, dus dit shipte ongemerkt. Bewezen met een SSR-rendertest die vóór de fix faalde met exact deze ReferenceError.

**Bug 2, TDZ:** in `OnboardingFlowPage.tsx` (`handleSubmit` → `doSubmit`) stond `if (user?.id) clearProgressFromSupabase(user.id);` vóór `let user: any = null;` in dezelfde scope. Optional chaining beschermt niet tegen de temporal dead zone: elke submit gooide `ReferenceError: Cannot access 'user' before initialization`, werd opgevangen door de try/catch rond `Promise.race`, en viel terug op `applyFallback`. Gevolg: Supabase-sync en het gegenereerde stijlprofiel werden bij elke submit stilletjes overgeslagen, plus een onterechte error-toast.

## Fix

- `CalibrationStep.tsx`: `import { Spinner } from '@/components/ui/Spinner';` toegevoegd (zelfde patroon als RequireQuiz, PhotoUpload, BramsFruitCatalogPage).
- `OnboardingFlowPage.tsx`: regel 586 gebruikt nu de eerder opgehaalde `userId` in plaats van de nog niet gedeclareerde `user`.

## Test

- Nieuwe regressietest `src/components/quiz/__tests__/CalibrationStep.render.test.tsx`: rendert de loading-branch via `renderToString` (node env, geen jsdom). Rood vóór de fix (`Spinner is not defined`), groen erna.
- `npm run build` slaagt.

## Buiten scope (bewust niet gefixt)

- `AdaptiveCalibrationStep.tsx` heeft dezelfde ontbrekende Spinner-import, maar wordt nergens geïmporteerd (dead code).
- `vite build` draait geen typecheck; een `tsc --noEmit` in CI had beide bugs gevangen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)