### PR TITLE
fix(build): dubbele Spinner-import brak de build op main

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,12 @@
 [build]
 publish = "dist"
 functions = "netlify/functions"
-command = "npx vite build"
+# `npm run build` = `tsc --noEmit && vite build`. Stond hier eerder als
+# `npx vite build`, dus zonder typecheck, terwijl de site-instelling in het
+# Netlify-dashboard wel `npm run build` draaide. Die twee spraken elkaar tegen
+# en het dashboard won. Nu staat de poort in versiebeheer, waar hij hoort:
+# wie het buildcommando leest, ziet meteen dat de typecheck erbij hoort.
+command = "npm run build"
 
 [build.environment]
 NODE_VERSION = "20"

--- a/src/components/quiz/CalibrationStep.tsx
+++ b/src/components/quiz/CalibrationStep.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
-import Spinner from '@/components/ui/Spinner';
 import { OutfitCalibrationCard } from './OutfitCalibrationCard';
 import { Sparkles, ArrowRight, CheckCircle2, TrendingUp } from 'lucide-react';
 import { Spinner } from '@/components/ui/Spinner';


### PR DESCRIPTION
De merge van #71 bracht twee imports van hetzelfde component samen: een default-import uit mijn branch en een named import die via #70 op main stond. Beide werken los, git zag geen conflict omdat het verschillende regels zijn, maar samen geven ze `TS2300: Duplicate identifier 'Spinner'` en faalt de build.

Verificatie op het merge-resultaat: typecheck 0 fouten, 204 tests groen, `npm run build` slaagt.

Daarnaast `netlify.toml` gelijkgetrokken met wat er werkelijk draaide: het bestand zei `npx vite build` (zonder typecheck), het dashboard draaide `npm run build` (met). Het dashboard won, waardoor deze fout alsnog is gepakt. Nu staat de poort in versiebeheer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)