### PR TITLE
fix(build): buildcommando terug naar vite, devDependencies hersteld

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,19 @@
 [build]
 publish = "dist"
 functions = "netlify/functions"
-# `npm run build` = `tsc --noEmit && vite build`. Stond hier eerder als
-# `npx vite build`, dus zonder typecheck, terwijl de site-instelling in het
-# Netlify-dashboard wel `npm run build` draaide. Die twee spraken elkaar tegen
-# en het dashboard won. Nu staat de poort in versiebeheer, waar hij hoort:
-# wie het buildcommando leest, ziet meteen dat de typecheck erbij hoort.
-command = "npm run build"
+# LET OP: hier hoort GEEN `npm run build` te staan, hoe verleidelijk ook.
+#
+# `npm run build` is `tsc --noEmit && vite build`, en die typecheck kan op de
+# buildmachine niet slagen. package.json heeft een preinstall-hook
+# (scripts/bolt-install.mjs) die voor de installatie alles wegknipt wat op
+# /^(eslint|prettier|husky|vitest|@types\/|...)/ matcht. Op Netlify staan er dus
+# geen @types/react en @types/react-dom, en dan geeft tsc TS2688 "Cannot find
+# type definition file for 'react'" en faalt de build met exit code 2.
+#
+# Op 2026-08-07 heb ik dit "rechtgezet" naar npm run build en daarmee vier
+# builds op rij gesloopt. De typecheck hoort in CI of lokaal te draaien, waar
+# de devDependencies er wel zijn, niet hier.
+command = "npx vite build"
 
 [build.environment]
 NODE_VERSION = "20"

--- a/package.json
+++ b/package.json
@@ -45,12 +45,16 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@types/node": "^25.1.0",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "terser": "^5.44.1",
     "typescript": "^5.9.2",
-    "vite": "^5.4.20"
+    "vite": "^5.4.20",
+    "vitest": "^1.6.1"
   }
 }


### PR DESCRIPTION
Herstelt twee fouten die ik in #72 en #73 heb geïntroduceerd.

**Het buildcommando.** Ik zette `netlify.toml` van `npx vite build` naar `npm run build` omdat het leek alsof de typecheck ontbrak. Die kan daar niet draaien: `package.json` heeft een preinstall-hook (`scripts/bolt-install.mjs`) die voor de installatie alles wegknipt wat op `/^(eslint|prettier|husky|vitest|@types\/|...)/` matcht. Zonder `@types/react` geeft `tsc` TS2688 en faalt de build. Terug naar `npx vite build`, met een comment die uitlegt waarom, zodat dit niet opnieuw "rechtgezet" wordt.

**De devDependencies.** Datzelfde preinstall-script herschrijft `package.json` op schijf. Toen ik `npm install --package-lock-only` draaide om `@types/node` toe te voegen, knipte het `@types/react`, `@types/react-dom` en `vitest` eruit, en die uitgeklede versie is in #73 meegemerged. Hersteld; lockfile bijgewerkt met `--ignore-scripts`.

Verificatie: typecheck 0 fouten, 15 testbestanden en 204 tests groen, `npx vite build` slaagt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)