### PR TITLE
fix(dashboard): zelfde engine en zelfde outfits als /results

### DIFF
--- a/src/components/dashboard/RefineStyleWidget.tsx
+++ b/src/components/dashboard/RefineStyleWidget.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Sparkles, ArrowRight, CheckCircle2 } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import { useNavigate } from 'react-router-dom';
+import { getSessionId } from '@/utils/sessionId';
 
 export function RefineStyleWidget() {
   const [skipped, setSkipped] = useState(false);
@@ -44,7 +45,10 @@ export function RefineStyleWidget() {
       } else {
         setSkipped(localSkipped);
 
-        const sessionId = localStorage.getItem('fitfi_session_id');
+        // sessionStorage, niet localStorage: sessionId.ts is de enige schrijver
+        // en schrijft daarheen. Deze regel las jarenlang een sleutel die nooit
+        // gezet werd en kreeg dus altijd null.
+        const sessionId = getSessionId();
         if (sessionId) {
           const { getSupabase } = await import('@/lib/supabase');
           const client = getSupabase();

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -79,10 +79,10 @@ export default function DashboardPage() {
   const isPremium = ctxUser?.tier === "premium" || ctxUser?.tier === "founder" || !!ctxUser?.isPremium;
   const isFounder = ctxUser?.tier === "founder";
 
-  const { color, archetype, gender, hasReport, hasPhoto, reportDate } = React.useMemo(() => {
+  const { color, archetype, gender, hasReport, hasPhoto, reportDate, answers } = React.useMemo(() => {
     const c = readJson<ColorProfile>(LS_KEYS.COLOR_PROFILE);
     const a = readJson<Archetype>(LS_KEYS.ARCHETYPE);
-    const ans = readJson<{ photoUrl?: string; gender?: string }>(LS_KEYS.QUIZ_ANSWERS);
+    const ans = readJson<any>(LS_KEYS.QUIZ_ANSWERS);
     const ts = localStorage.getItem(LS_KEYS.RESULTS_TS);
     return {
       color: c,
@@ -91,10 +91,46 @@ export default function DashboardPage() {
       hasReport: !!(a || c),
       hasPhoto: !!(ans?.photoUrl),
       reportDate: formatDate(ts),
+      answers: ans,
     };
   }, []);
 
-  const { data: outfitsData } = useOutfits({ archetype: archetype ?? undefined, gender: gender as any, limit: 6, enabled: hasReport });
+  // Zelfde limiet als /results (EnhancedResultsPage.tsx:380-387). Dit is geen
+  // cosmetiek: de queryKey is ['outfits','v2', digest, limit] (useOutfits.ts:78).
+  // Bij een andere limiet krijg je een tweede cache-entry en dus een tweede
+  // engine-run, en de engine seedt op de klok als er geen seed meekomt
+  // (engine.ts:722, Math.floor(Date.now()/300000)). Twee runs in verschillende
+  // vijf-minutenvakken geven een ANDERE outfitset. Gelijke limiet betekent
+  // dezelfde sleutel, dus letterlijk dezelfde outfits op beide schermen.
+  const outfitLimit = React.useMemo(() => {
+    if (!ctxUser) return 6;
+    const tier = (ctxUser as any).tier || ((ctxUser as any).isPremium ? "premium" : "member");
+    if (tier === "founder") return 20;
+    if (tier === "premium" || tier === "plus") return 12;
+    if (tier === "member") return 9;
+    return 6;
+  }, [ctxUser]);
+
+  // `answers` meegeven zet dit scherm op engine v2, hetzelfde pad als /results
+  // (useOutfits.ts:107). Zonder die prop liep het dashboard via de legacy-tak
+  // naar outfitComposer (v1). Twee gevolgen, allebei gemeten:
+  //
+  // 1. Het dashboard gaf HELEMAAL GEEN budget door, dus wie zijn budget op 15
+  //    euro zette kreeg hier zes outfits en op /results nul. Dat verschil kwam
+  //    dus niet van de engine maar van een weggelaten filter.
+  // 2. v1 kijkt nooit naar `sizes` (productFilter.ts:76-93) en zijn maatregel
+  //    matcht "Maat 92" niet. Een peuterschoen in maat 28 t/m 31 en een
+  //    "Hello Kitty sneaker" komen er bij v1 gewoon doorheen, bij v2 niet.
+  //
+  // De seizoenscheck is GEEN argument: v1 heeft een eigen seizoensfilter
+  // (outfitComposer.ts:317-321). Dat had ik eerst verkeerd opgeschreven.
+  const { data: outfitsData } = useOutfits({
+    archetype: archetype ?? undefined,
+    gender: gender as any,
+    limit: outfitLimit,
+    enabled: hasReport,
+    answers: answers ?? undefined,
+  });
 
   React.useEffect(() => {
     const client = supabase();

--- a/src/services/nova/userContext.ts
+++ b/src/services/nova/userContext.ts
@@ -1,4 +1,5 @@
 import { requireSupabase } from "@/lib/supabase";
+import { getSessionId as gedeeldSessionId } from "@/utils/sessionId";
 
 export interface ColorProfile {
   undertone: "warm" | "cool" | "neutral";
@@ -178,7 +179,9 @@ function parseColorProfile(data: any): ColorProfile {
 
 function getSessionId(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("fitfi_session_id") || sessionStorage.getItem("fitfi_session_id");
+  // Las eerst localStorage, waar nooit iets in wordt gezet, en pas daarna
+  // sessionStorage. Dat werkte toevallig, maar alleen dankzij de tweede helft.
+  return gedeeldSessionId();
 }
 
 export function buildSystemPrompt(context: NovaUserContext): string {

--- a/src/services/outfits/outfitService.ts
+++ b/src/services/outfits/outfitService.ts
@@ -4,6 +4,7 @@ import { runEngineV2 } from "@/engine/v2";
 import { generateNovaExplanation } from "@/engine/explainOutfit";
 import { filterByGender, getUserGender } from "@/services/products/genderFilter";
 import { reclassifyProducts } from "@/engine/productClassifier";
+import { filterVeiligeProducten } from "@/engine/productSafety";
 import { dedupeProductVariants } from "./dedupeProductVariants";
 import type { Product } from "@/engine/types";
 import type { Outfit } from "@/engine/types";
@@ -70,7 +71,27 @@ class OutfitService {
 
       const rawProducts = dedupeProductVariants(data.map(this.mapDatabaseProduct));
 
-      const { classified: products } = reclassifyProducts(rawProducts);
+      const { classified } = reclassifyProducts(rawProducts);
+
+      // Veiligheidsnet hier, op de pool, en niet pas in candidateFilter.
+      // Reden: als engine v2 nul outfits geeft valt generateOutfits terug op
+      // generateRecommendationsFromAnswers (regel ~121), een derde engine die
+      // beoordeelProduct nergens aanroept. Zat de check alleen in
+      // candidateFilter.ts:238, dan omzeilde precies die terugval het net en
+      // kon er alsnog kinderkleding op /results komen. Nu krijgt elke
+      // afnemer van deze pool dezelfde grens.
+      //
+      // reclassifyProducts heeft de categorie op dit punt al genormaliseerd
+      // naar onder meer 'footwear', dus de maatcontrole voor kinderschoenen
+      // werkt hier zoals bedoeld.
+      const { veilig: products, geweigerd } = filterVeiligeProducten(classified);
+      if (geweigerd.length > 0) {
+        const perReden = geweigerd.reduce<Record<string, number>>((acc, g) => {
+          acc[g.reden] = (acc[g.reden] ?? 0) + 1;
+          return acc;
+        }, {});
+        console.log('[OutfitService] veiligheidsnet weigerde producten:', perReden);
+      }
 
       this.productsCache.set(cacheKey, products);
       this.cacheTimestamps.set(cacheKey, Date.now());


### PR DESCRIPTION
Het dashboard gaf geen `answers` mee aan `useOutfits` en liep daardoor via de legacy-tak naar `outfitComposer` (v1), terwijl `/results` engine v2 gebruikt.

**De oorzaak van het 6-tegen-0 gat was een andere dan gedacht.** Gemeten op de fixture: het dashboard gaf helemaal geen budget door en draaide dus de "geen budget"-variant met zes outfits, terwijl `/results` budgetRange 15 doorgaf en op nul uitkwam. Niet de engine, maar een weggelaten filter.

Wat wel echt aan de engine ligt: v1 kijkt nooit naar `sizes` en zijn maatregel matcht "Maat 92" niet. Een schoen in maat 28-31 en een "Hello Kitty sneaker" komen er bij v1 doorheen. De seizoenscheck is géén argument, v1 heeft een eigen seizoensfilter.

**Dezelfde limiet is niet cosmetisch.** De queryKey bevat de limiet, dus een andere waarde geeft een tweede cache-entry en een tweede engine-run, en de engine seedt op de klok als er geen seed meekomt. Twee runs in verschillende vijf-minutenvakken geven een andere outfitset. Nu delen beide schermen één entry.

**Veiligheidsnet naar de productpool.** `beoordeelProduct` zat alleen in `candidateFilter`, binnen v2. Geeft v2 nul outfits, dan valt `outfitService` terug op een derde engine die die check niet aanroept, juist wanneer de pool al dun is. Nu op de pool, met de check in candidateFilter als tweede lijn.

Verificatie: typecheck 0, 16 testbestanden en 206 tests groen, `npx vite build` slaagt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)