### PR TITLE
fix(sessie): twee sessie-identiteiten samengevoegd tot één

### DIFF
--- a/src/components/quiz/PhotoUpload.tsx
+++ b/src/components/quiz/PhotoUpload.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from "react";
 import { Spinner } from '@/components/ui/Spinner';
 import { motion, AnimatePresence } from "framer-motion";
 import { Camera, Upload, AlertCircle, CheckCircle, Shield, X, Info, ImageIcon } from "lucide-react";
+import { getSessionId } from '@/utils/sessionId';
 
 interface ColorAnalysis {
   undertone: "warm" | "cool" | "neutral";
@@ -68,8 +69,7 @@ export default function PhotoUpload({ value, onChange, onAnalysisComplete }: Pro
     reader.onload = () => onChange((reader.result as string) || null);
     reader.readAsDataURL(file);
 
-    const sessionId = localStorage.getItem("ff_session_id") || crypto.randomUUID();
-    localStorage.setItem("ff_session_id", sessionId);
+    const sessionId = getSessionId();
 
     setUploading(true);
     try {

--- a/src/pages/EnhancedResultsPage.tsx
+++ b/src/pages/EnhancedResultsPage.tsx
@@ -50,6 +50,7 @@ import OutfitCard from "@/components/outfits/OutfitCard";
 import { OutfitPreviewCard } from "@/components/results/OutfitPreviewCard";
 import { openProductLink } from "@/utils/affiliate";
 import { getColorPalette } from "@/data/colorPalettes";
+import { getSessionId } from '@/utils/sessionId';
 
 function readJson<T>(key: string): T | null {
   try {
@@ -316,10 +317,10 @@ export default function EnhancedResultsPage() {
     async function generateProfile() {
       setProfileLoading(true);
       try {
-        const sessionId = user?.id || localStorage.getItem('ff_session_id') || crypto.randomUUID();
-        if (!user?.id) {
-          localStorage.setItem('ff_session_id', sessionId);
-        }
+        // getSessionId() slaat zelf op; hier hoeft niets meer geschreven te
+        // worden. Is er een ingelogde gebruiker, dan telt zijn id en blijft
+        // het anonieme sessie-id ongemoeid.
+        const sessionId = user?.id || getSessionId();
 
         const result = await StyleProfileGenerator.generateStyleProfile(
           answers,

--- a/src/pages/OnboardingFlowPage.tsx
+++ b/src/pages/OnboardingFlowPage.tsx
@@ -21,6 +21,7 @@ import { ArchetypePreviewEnhanced as ArchetypePreview } from "@/components/quiz/
 import { useUser } from "@/context/UserContext";
 import toast from "react-hot-toast";
 import track from "@/utils/telemetry";
+import { getSessionId, resetSessionId } from '@/utils/sessionId';
 
 type QuizAnswers = {
   gender?: string;
@@ -96,7 +97,7 @@ export default function OnboardingFlowPage() {
   const [phase, setPhase] = useState<QuizPhase>('questions');
   const [progressLoaded, setProgressLoaded] = useState(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const [sessionId] = useState(() => localStorage.getItem('ff_session_id') || crypto.randomUUID());
+  const [sessionId] = useState(getSessionId);
   const [showEmailCapture, setShowEmailCapture] = useState(false);
   const [emailCaptured, setEmailCaptured] = useState(() => {
     return !!localStorage.getItem('ff_email_captured');
@@ -425,7 +426,7 @@ export default function OnboardingFlowPage() {
   const confirmCancel = () => {
     track("quiz_abandoned", { phase, step: currentStep, answeredFields: Object.keys(answers).length });
     localStorage.removeItem(LS_KEYS.QUIZ_ANSWERS);
-    localStorage.removeItem('ff_session_id');
+    resetSessionId();
     navigate('/');
   };
 
@@ -603,7 +604,7 @@ export default function OnboardingFlowPage() {
       localStorage.setItem(LS_KEYS.RESULTS_TS, Date.now().toString());
       localStorage.setItem(LS_KEYS.QUIZ_COMPLETED, "1");
       localStorage.removeItem('ff_quiz_step');
-      localStorage.setItem('ff_session_id', sessionId);
+      /* sessie-id staat al vast via getSessionId() */
       if (userId) clearProgressFromSupabase(userId);
 
       // client and userId already declared above

--- a/src/services/data/profileSyncService.ts
+++ b/src/services/data/profileSyncService.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/lib/supabaseClient";
 import { LS_KEYS } from "@/lib/quiz/types";
+import { getSessionId } from '@/utils/sessionId';
 
 export type SyncStatus = 'synced' | 'pending' | 'error' | 'unknown';
 
@@ -152,7 +153,7 @@ class ProfileSyncService {
           console.warn('[ProfileSync] ⚠️ No profile found in database for user');
         }
       } else {
-        const sessionId = localStorage.getItem('ff_session_id');
+        const sessionId = getSessionId();
         console.log('[ProfileSync] No user, checking session:', sessionId?.substring(0, 8));
 
         if (sessionId) {
@@ -219,11 +220,8 @@ class ProfileSyncService {
       }
 
       const { data: { user } } = await client.auth.getUser();
-      const sessionId = localStorage.getItem('ff_session_id') || crypto.randomUUID();
+      const sessionId = getSessionId();
 
-      if (!localStorage.getItem('ff_session_id')) {
-        localStorage.setItem('ff_session_id', sessionId);
-      }
 
       console.log('[ProfileSync] 💾 Starting sync...', {
         hasUser: !!user,

--- a/src/services/nova/conversationService.ts
+++ b/src/services/nova/conversationService.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabaseClient";
+import { getSessionId } from '@/utils/sessionId';
 
 export interface NovaMessage {
   role: 'user' | 'assistant';
@@ -25,11 +26,8 @@ class ConversationService {
 
     try {
       const { data: { user } } = await client.auth.getUser();
-      const sessionId = localStorage.getItem('ff_session_id') || crypto.randomUUID();
+      const sessionId = getSessionId();
 
-      if (!localStorage.getItem('ff_session_id')) {
-        localStorage.setItem('ff_session_id', sessionId);
-      }
 
       const query = user
         ? client.from('nova_conversations').select('*').eq('user_id', user.id)

--- a/src/services/visualPreferences/calibrationService.ts
+++ b/src/services/visualPreferences/calibrationService.ts
@@ -3,6 +3,7 @@ import type { VisualPreferenceEmbedding } from './visualPreferenceService';
 import type { ArchetypeWeights } from '@/types/style';
 import { ColorHarmonyService } from './colorHarmony';
 import { filterVeiligeProducten, type SafetyInput } from '@/engine/productSafety';
+import { getSessionId } from '@/utils/sessionId';
 
 export interface CalibrationOutfitItem {
   id: string;
@@ -543,7 +544,7 @@ export class CalibrationService {
   private static async getBrandAffinityMap(supabase: any): Promise<Record<string, number>> {
     try {
       const userId = (await supabase.auth.getUser()).data.user?.id;
-      const sessionId = sessionStorage?.getItem?.('fitfi_session_id');
+      const sessionId = getSessionId();
 
       if (!userId && !sessionId) {
         return {};

--- a/src/utils/__tests__/sessionId.test.ts
+++ b/src/utils/__tests__/sessionId.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getSessionId, isUuid } from '../sessionId';
+import { getSessionId, isUuid, resetSessionId } from '../sessionId';
 
 /** Minimale sessionStorage voor de node-omgeving. */
 function nepOpslag() {
@@ -17,7 +17,9 @@ function nepOpslag() {
 }
 
 beforeEach(() => {
+  vi.stubGlobal('localStorage', nepOpslag());
   vi.stubGlobal('sessionStorage', nepOpslag());
+  vi.stubGlobal('window', { localStorage, sessionStorage });
 });
 
 describe('isUuid', () => {
@@ -51,30 +53,54 @@ describe('getSessionId', () => {
     // Dit is de kern: raakte de gebruiker eerst een affiliate-link aan, dan
     // stond er een niet-uuid in de sleutel en faalde daarna elke insert op
     // style_swipes en swipe_preferences, die allebei UUID NOT NULL zijn.
-    sessionStorage.setItem('fitfi_session_id', '1754521234567_x8k2m9qp1');
+    localStorage.setItem('ff_session_id', '1754521234567_x8k2m9qp1');
 
     const id = getSessionId();
 
     expect(isUuid(id)).toBe(true);
-    expect(sessionStorage.getItem('fitfi_session_id')).toBe(id);
+    expect(localStorage.getItem('ff_session_id')).toBe(id);
   });
 
   it('respecteert een uuid die er al stond', () => {
     const bestaand = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
-    sessionStorage.setItem('fitfi_session_id', bestaand);
+    localStorage.setItem('ff_session_id', bestaand);
 
     expect(getSessionId()).toBe(bestaand);
   });
 
-  it('valt niet om als sessionStorage gooit', () => {
-    vi.stubGlobal('sessionStorage', {
-      getItem: () => {
-        throw new Error('private mode');
-      },
-      setItem: () => {
-        throw new Error('private mode');
-      },
-    } as unknown as Storage);
+  it('neemt een geldige uuid over uit de oude sessionStorage-sleutel', () => {
+    // Zo raakt iemand die midden in de quiz zit zijn swipes niet kwijt.
+    const oud = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+    sessionStorage.setItem('fitfi_session_id', oud);
+
+    expect(getSessionId()).toBe(oud);
+    expect(localStorage.getItem('ff_session_id')).toBe(oud);
+  });
+
+  it('neemt een ONgeldige waarde uit de oude sleutel niet over', () => {
+    sessionStorage.setItem('fitfi_session_id', '1754521234567_x8k2m9qp1');
+
+    const id = getSessionId();
+    expect(isUuid(id)).toBe(true);
+    expect(id).not.toBe('1754521234567_x8k2m9qp1');
+  });
+
+  it('resetSessionId wist beide sleutels', () => {
+    const eerste = getSessionId();
+    resetSessionId();
+    expect(localStorage.getItem('ff_session_id')).toBeNull();
+    expect(getSessionId()).not.toBe(eerste);
+  });
+
+  it('valt niet om als de opslag gooit', () => {
+    const kapot = {
+      getItem: () => { throw new Error('private mode'); },
+      setItem: () => { throw new Error('private mode'); },
+      removeItem: () => { throw new Error('private mode'); },
+    } as unknown as Storage;
+    vi.stubGlobal('localStorage', kapot);
+    vi.stubGlobal('sessionStorage', kapot);
+    vi.stubGlobal('window', { localStorage: kapot, sessionStorage: kapot });
 
     expect(isUuid(getSessionId())).toBe(true);
   });

--- a/src/utils/sessionId.ts
+++ b/src/utils/sessionId.ts
@@ -1,27 +1,40 @@
 /**
- * Eén sessie-id voor de hele app, en het moet een UUID zijn.
+ * Eén sessie-id voor de hele app.
  *
- * Aanleiding (2026-08-07). Twee plekken schreven naar dezelfde sleutel
- * `fitfi_session_id` in sessionStorage, met een ander formaat:
+ * De app had er twee, met verschillende sleutels EN verschillende opslag:
  *
- *   - src/components/quiz/VisualPreferenceStepClean.tsx zette er een
- *     crypto.randomUUID() in;
- *   - src/utils/affiliate.ts zette er `${Date.now()}_${random}` in, dus
- *     bijvoorbeeld "1754521234567_x8k2m9qp1".
+ *   ff_session_id      localStorage    profiel claimen, foto-upload, Nova
+ *   fitfi_session_id   sessionStorage  swipes, calibratie
  *
- * Wie het eerst schreef, won. De kolom swipe_preferences.session_id is
- * `UUID NOT NULL`, en style_swipes.session_id ook. Had een gebruiker dus
- * ergens een affiliate-link aangeraakt voordat hij bij de swipes of de
- * calibratie kwam, dan stond er een niet-UUID in de sleutel en faalde daarna
- * elke insert en elke RPC op een castfout. Die fouten werden alleen
- * ge-console.error'd, dus de gebruiker merkte niets en de data verdween.
+ * Die matchten nooit. Een anonieme gebruiker schreef zijn swipes weg onder het
+ * ene id (style_swipes.session_id) en zijn stijlprofiel onder het andere
+ * (style_profiles.session_id), waardoor de twee niet aan elkaar te koppelen
+ * waren. De visuele voorkeur die uit de swipes wordt berekend kon dus nooit bij
+ * het profiel terechtkomen waar hij bij hoorde.
  *
- * Deze module is de enige plek die de sleutel mag zetten. Een waarde die er
- * al staat maar geen UUID is, wordt vervangen: liever een nieuwe sessie dan
- * een sessie die niets kan opslaan.
+ * Gekozen: ff_session_id in localStorage.
+ *
+ * De sleutel omdat de meeste plekken die al gebruiken, waaronder de enige die
+ * er echt van afhangt: profileSyncService.ts:155 zoekt bij een volgend bezoek
+ * het anonieme profiel op via deze id.
+ *
+ * localStorage en niet sessionStorage omdat een sessie hier "dit apparaat"
+ * betekent en niet "dit tabblad". De hele anonieme flow is: quiz doen,
+ * resultaten bekijken, later terugkomen en een account maken om het profiel te
+ * claimen. Met sessionStorage gooit het sluiten van de tab de enige verwijzing
+ * naar dat profiel weg. Dat OnboardingFlowPage.tsx:428 de id expliciet wist bij
+ * een quiz-reset is het bewijs dat hij normaal juist hoort te blijven staan.
+ *
+ * Het moet een UUID zijn: style_swipes.session_id en swipe_preferences.session_id
+ * zijn allebei UUID NOT NULL. Een waarde in een ander formaat, zoals de
+ * `${Date.now()}_${random}` die affiliate.ts hier vroeger in zette, laat elke
+ * insert stuk lopen op een castfout die alleen in de console belandt.
  */
 
-const KEY = 'fitfi_session_id';
+const KEY = 'ff_session_id';
+
+/** Oude sleutel uit sessionStorage. Alleen om lopende bezoeken over te nemen. */
+const OUDE_KEY = 'fitfi_session_id';
 
 const UUID_PATROON =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -48,17 +61,46 @@ function nieuweUuid(): string {
   });
 }
 
-/** Het sessie-id voor deze tab. Altijd een geldige UUID. */
-export function getSessionId(): string {
+function lees(opslag: Storage | undefined, sleutel: string): string | null {
   try {
-    const bestaand = sessionStorage.getItem(KEY);
-    if (isUuid(bestaand)) return bestaand as string;
-
-    const nieuw = nieuweUuid();
-    sessionStorage.setItem(KEY, nieuw);
-    return nieuw;
+    return opslag?.getItem(sleutel) ?? null;
   } catch {
-    // sessionStorage kan gooien in private mode of met geblokkeerde cookies.
-    return nieuweUuid();
+    return null; // private mode, geblokkeerde cookies
+  }
+}
+
+/**
+ * Het sessie-id voor dit apparaat. Altijd een geldige UUID.
+ *
+ * Neemt eenmalig een geldige waarde over uit de oude sessionStorage-sleutel,
+ * zodat iemand die midden in de quiz zit zijn swipes niet kwijtraakt.
+ */
+export function getSessionId(): string {
+  if (typeof window === 'undefined') return nieuweUuid();
+
+  const bestaand = lees(window.localStorage, KEY);
+  if (isUuid(bestaand)) return bestaand as string;
+
+  const overgenomen = lees(window.sessionStorage, OUDE_KEY);
+  const id = isUuid(overgenomen) ? (overgenomen as string) : nieuweUuid();
+
+  try {
+    window.localStorage.setItem(KEY, id);
+  } catch {
+    // Niet kunnen opslaan is vervelend maar niet fataal: de aanroeper krijgt
+    // een geldige id en de insert slaagt. Alleen een volgend bezoek herkent
+    // deze gebruiker dan niet meer.
+  }
+  return id;
+}
+
+/** Wist het sessie-id. Alleen gebruiken bij een bewuste reset van de quiz. */
+export function resetSessionId(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(KEY);
+    window.sessionStorage.removeItem(OUDE_KEY);
+  } catch {
+    /* niets te doen */
   }
 }


### PR DESCRIPTION
De app hield **twee** losse sessie-ids bij, met verschillende sleutels én verschillende opslag:

| sleutel | opslag | gebruikt door |
|---|---|---|
| `ff_session_id` | localStorage | profiel claimen, foto-upload, Nova |
| `fitfi_session_id` | sessionStorage | swipes, calibratie |

Die matchten nooit. Een anonieme gebruiker schreef zijn swipes weg onder het ene id (`style_swipes.session_id`) en zijn stijlprofiel onder het andere (`style_profiles.session_id`). De visuele voorkeur die uit die swipes wordt berekend kon dus nooit bij het bijbehorende profiel komen. Dat is precies waar de swipe-stap voor bestaat.

**Gekozen: `ff_session_id` in localStorage.** De sleutel omdat `profileSyncService.ts:155` bij een volgend bezoek het anonieme profiel daarmee opzoekt. localStorage omdat een sessie hier "dit apparaat" betekent en niet "dit tabblad": de flow is quiz doen, later terugkomen, account maken en het profiel claimen. Dat de onboarding de id expliciet wist bij een reset bewijst dat hij normaal hoort te blijven staan. Mijn vorige commit zette dit op sessionStorage, dat was de verkeerde kant op.

Migratie meegenomen: een geldige UUID in de oude sessionStorage-sleutel wordt overgenomen, zodat wie nu midden in de quiz zit zijn swipes niet kwijtraakt.

Alle twaalf plekken lopen nu via `src/utils/sessionId.ts`. Vijf overbodige schrijfblokken weg.

Verificatie: typecheck 0, 16 testbestanden en 209 tests groen, `npx vite build` slaagt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)