### PR TITLE
fix: preinstall-val gedicht, CI-poort toegevoegd, laatste onwaarheden weg

### DIFF
--- a/.github/workflows/controle.yml
+++ b/.github/workflows/controle.yml
@@ -1,0 +1,56 @@
+# Poort vóór de merge: typecheck, tests en build.
+#
+# Waarom hier en niet in de Netlify-build: netlify.toml draait `npx vite build`
+# zonder typecheck, en dat is bewust zo (zie de toelichting in dat bestand).
+# Een poort die pas bij het deployen afgaat, legt bovendien de site plat in
+# plaats van een pull request tegen te houden. Op 2026-08-07 kostte precies dat
+# vier gefaalde productiebuilds op rij.
+#
+# --ignore-scripts is niet optioneel: scripts/bolt-install.mjs is een
+# preinstall-hook die package.json op schijf herschrijft en dev-tooling
+# wegknipt. Zonder deze vlag draait de suite hier zonder vitest en zonder
+# @types/react.
+#
+# Deze workflow leest bewust GEEN gegevens uit de gebeurtenis (geen titels,
+# beschrijvingen of branchnamen in een run-stap). Alles wat hier draait staat
+# vast in dit bestand, dus er is geen weg naar binnen via een pull request.
+
+name: Controle
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  controle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Afhankelijkheden installeren
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Tests
+        run: npx vitest run --reporter=basic
+
+      # Dit is het commando dat Netlify ook draait. Faalt het hier, dan faalt
+      # de deploy straks ook, en dan weet je het vóór de merge.
+      - name: Build
+        run: npx vite build

--- a/scripts/bolt-install.mjs
+++ b/scripts/bolt-install.mjs
@@ -1,5 +1,31 @@
 #!/usr/bin/env node
+/*
+ * Preinstall-hook voor Bolt: knipt zware dev-tooling uit package.json zodat de
+ * import daar licht blijft.
+ *
+ * BELANGRIJK, toegevoegd 2026-08-07: dit script HERSCHRIJFT package.json op
+ * schijf. Het draaide bij elke `npm install`, ook lokaal, en gooide dan
+ * @types/react, @types/react-dom, vitest, eslint en prettier uit je bestand.
+ * Wie daarna committe, verwijderde die pakketten uit de repo zonder het te
+ * merken. Dat is op 2026-08-07 gebeurd (zie #73) en het kostte drie kapotte
+ * productiebuilds voordat duidelijk was waar het vandaan kwam.
+ *
+ * Daarom draait het nu alleen nog wanneer BOLT_TRIM=1 is gezet. Bolt zelf kan
+ * die variabele meegeven; zonder die variabele doet npm install wat je
+ * verwacht. `.bolt/` is voor het laatst aangeraakt in maart 2026, dus in de
+ * praktijk staat deze hook stil.
+ *
+ * Draai je hem toch, gebruik dan `npm install --ignore-scripts` als je alleen
+ * de lockfile wilt bijwerken.
+ */
 import fs from "node:fs";
+
+if (process.env.BOLT_TRIM !== "1") {
+  console.log(
+    "bolt-install: overgeslagen (zet BOLT_TRIM=1 om dev-deps te strippen)"
+  );
+  process.exit(0);
+}
 
 const pkgPath = "package.json";
 const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -14,7 +14,6 @@ import {
   Info,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabaseClient";
 import { useTestimonials } from "@/hooks/useTestimonials";
 
 /* ─── Scroll-reveal wrapper ─── */
@@ -54,24 +53,13 @@ const marqueeCSS = `
 export default function LandingPage() {
   const navigate = useNavigate();
 
-  /* Preserve existing data-fetching */
-  const { data: todayCount } = useQuery({
-    queryKey: ["profiles-today"],
-    queryFn: async () => {
-      const sb = supabase();
-      if (!sb) return 0;
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      const { count, error } = await sb
-        .from("style_profiles")
-        .select("*", { count: "exact", head: true })
-        .gte("created_at", today.toISOString());
-      if (error) throw error;
-      return count || 0;
-    },
-    staleTime: 60000,
-    refetchInterval: 60000,
-  });
+  /*
+   * Hier stond een useQuery die het aantal style_profiles van vandaag telde.
+   * Die uitkomst werd nergens gerenderd: een Supabase-request bij elk bezoek
+   * aan de drukste pagina, waarvan het antwoord werd weggegooid. Bovendien gaf
+   * hij voor uitgelogde bezoekers altijd 0 terug, want RLS staat anon geen
+   * telling op style_profiles toe.
+   */
 
   const { testimonials } = useTestimonials();
 
@@ -124,12 +112,13 @@ export default function LandingPage() {
    * (commits 7b1479f4 en a29a2595) omdat het getal nergens op steunt. Deze
    * ene stond nog.
    *
-   * "2.400+ gebruikers" laat ik staan: dat kan kloppen, maar ik kon het niet
-   * controleren omdat RLS de telling op style_profiles blokkeert voor anon.
-   * Als dat cijfer niet klopt, hoort het hier ook weg.
+   * "2.400+ gebruikers" is er op 2026-08-07 ook afgehaald. Niet omdat het
+   * aantoonbaar onwaar is, maar omdat het niet te controleren viel: RLS staat
+   * anon geen telling op style_profiles toe. Naast twee claims die wel
+   * aantoonbaar onwaar bleken, is een oncontroleerbaar getal geen houdbare
+   * positie. Klopt het wel, zet het dan terug met de bron erbij.
    */
   const marqueeItems = [
-    { bold: "2.400+", rest: "gebruikers" },
     { bold: "~5 min", rest: "invultijd" },
     { bold: "Gratis", rest: "geen creditcard" },
     { bold: "Persoonlijk", rest: "kleurpalet" },

--- a/src/services/visualPreferences/visualPreferenceService.ts
+++ b/src/services/visualPreferences/visualPreferenceService.ts
@@ -41,6 +41,14 @@ export interface NovaSwipeInsight {
   created_at?: string;
 }
 
+/** Fisher-Yates, in-place. */
+function schud<T>(lijst: T[]): void {
+  for (let i = lijst.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [lijst[i], lijst[j]] = [lijst[j], lijst[i]];
+  }
+}
+
 export class VisualPreferenceService {
   private static getClient() {
     const client = getSupabase();
@@ -86,6 +94,10 @@ export class VisualPreferenceService {
 
     let photos = (data && data.length > 0) ? data : [];
 
+    // Wordt true wanneer we hieronder bewust een gebalanceerde volgorde
+    // opbouwen; de globale shuffle slaat die volgorde dan over.
+    let alGebalanceerd = false;
+
     // Hard gender filter: always strip photos belonging to the opposite gender.
     // Computed independently of gendersToTry so any future fallback paths can't bypass it.
     let allowedGenders: string[] | null = null;
@@ -97,29 +109,56 @@ export class VisualPreferenceService {
         (p: MoodPhoto) => !p.gender || allowedGenders!.includes(p.gender)
       );
     } else if (photos.length > 0) {
-      // Gender onbekend, non-binary of niet-opgegeven. Hiervoor bleef
-      // allowedGenders leeg en gebeurde er dus GEEN filtering: de gebruiker
-      // kreeg heren- en dameskleding door elkaar te swipen, wat het profiel
-      // vervuilt en verwarrend oogt. Nu eerst uitsluitend unisex tonen, en
-      // alleen terugvallen op de volledige set wanneer dat te weinig
-      // materiaal oplevert om fatsoenlijk te kunnen swipen.
-      const MIN_FOTOS = 12;
+      // Gender onbekend, non-binary of niet opgegeven.
+      //
+      // Eerst uitsluitend unisex, want dat is wat deze gebruiker vraagt. Maar
+      // gemeten op 2026-08-07 zijn er 86 actieve mood photos: 44 male, 42
+      // female, NUL unisex. De labels komen uit de uploadmap (/mood-photos/male/
+      // en /female/), niemand heeft foto's ooit op genderneutraliteit
+      // beoordeeld. Zolang dat zo is haalt deze tak zijn drempel nooit.
+      //
+      // De terugval is daarom geen randgeval maar het normale pad, en dan moet
+      // hij ook goed zijn. Een simpele shuffle over 86 foto's kan zomaar acht
+      // herenbeelden achter elkaar geven, en dan lijkt het alsof we een keuze
+      // hebben gemaakt die we niet hebben gemaakt. Daarom afwisselend een uit
+      // elke groep, zodat het beeld van begin af aan gemengd is.
+      const MIN_UNISEX = 12;
       const unisex = photos.filter((p: MoodPhoto) => !p.gender || p.gender === 'unisex');
-      if (unisex.length >= MIN_FOTOS) {
+
+      if (unisex.length >= MIN_UNISEX) {
         photos = unisex;
       } else {
+        const mannen = photos.filter((p: MoodPhoto) => p.gender === 'male');
+        const vrouwen = photos.filter((p: MoodPhoto) => p.gender === 'female');
+        const rest = photos.filter(
+          (p: MoodPhoto) => p.gender !== 'male' && p.gender !== 'female'
+        );
+
+        // Binnen elke groep schudden, daarna om en om samenvoegen. De globale
+        // shuffle verderop wordt hiervoor overgeslagen, want die zou de balans
+        // die we net hebben aangebracht meteen weer weggooien.
+        schud(mannen);
+        schud(vrouwen);
+        schud(rest);
+
+        const gemengd: MoodPhoto[] = [];
+        for (let i = 0; i < Math.max(mannen.length, vrouwen.length); i++) {
+          if (mannen[i]) gemengd.push(mannen[i]);
+          if (vrouwen[i]) gemengd.push(vrouwen[i]);
+        }
+        photos = [...gemengd, ...rest];
+        alGebalanceerd = true;
+
         console.warn(
-          `[VisualPreferenceService] Slechts ${unisex.length} unisex-foto's beschikbaar; ` +
-          'val terug op de volledige set. Voeg meer unisex mood photos toe.'
+          `[VisualPreferenceService] ${unisex.length} unisex-foto's, minder dan ${MIN_UNISEX}. ` +
+          `Toon een gebalanceerde mix van ${mannen.length} heren- en ${vrouwen.length} damesbeelden. ` +
+          'Label minstens 12 foto\'s als unisex om dit pad te verbeteren.'
         );
       }
     }
 
-    if (shuffle) {
-      for (let i = photos.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [photos[i], photos[j]] = [photos[j], photos[i]];
-      }
+    if (shuffle && !alGebalanceerd) {
+      schud(photos);
     }
 
     return photos;


### PR DESCRIPTION
## De preinstall-hook sloopte je package.json

`scripts/bolt-install.mjs` herschrijft `package.json` **op schijf** en knipt `@types/*`, `vitest`, `eslint` en `prettier` eruit. Hij draaide bij elke `npm install`, ook lokaal. Wie daarna committe, verwijderde die pakketten uit de repo zonder het te merken. Dat is mij vandaag overkomen (#73) en het kostte drie kapotte productiebuilds voordat duidelijk was waar het vandaan kwam.

Draait nu alleen nog met `BOLT_TRIM=1`. `.bolt/` is voor het laatst aangeraakt in maart 2026.

## CI-poort vóór de merge

Nieuw: `.github/workflows/controle.yml` met typecheck, tests en build op elke PR. Er bestond geen enkele workflow.

Bewust **niet** de Netlify-build aangepast, ook al zou dat nu kunnen: een poort die pas bij het deployen afgaat legt de site plat in plaats van een PR tegen te houden, en precies dat kostte vandaag vier gefaalde builds. De workflow draait `npx vite build`, hetzelfde commando als Netlify, met `--ignore-scripts` zodat de preinstall-hook vitest niet wegknipt.

## Twee dingen van de landingspagina

Een `useQuery` haalde bij elk bezoek het aantal profielen van vandaag op en gebruikte het **nergens**. Weg.

"2.400+ gebruikers" eraf. Niet omdat het aantoonbaar onwaar is, maar omdat het niet te controleren viel: RLS staat anon geen telling op `style_profiles` toe. Naast twee claims die vandaag wél onwaar bleken, is een oncontroleerbaar getal geen houdbare positie. Klopt het, zet het terug met de bron erbij.

## Mood photos: de terugval is het normale pad

Gemeten: 86 actieve foto's, 44 male, 42 female, **nul unisex**. De labels komen uit de uploadmap. De unisex-tak haalt zijn drempel dus nooit.

Die terugval was een shuffle over alles, waarbij je acht herenbeelden achter elkaar kunt krijgen. Nu om en om één uit elke groep, met een shuffle binnen de groepen. Het echte werk blijft data: label minstens twaalf foto's als unisex.

Verificatie: typecheck 0, 16 testbestanden en 209 tests groen, `npx vite build` slaagt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)