### PR TITLE
fix(admin): dashboardcrash en onbegrensde style_profiles-query

### DIFF
--- a/CLEANUP_DUPLICATE_STYLE_PROFILES.sql
+++ b/CLEANUP_DUPLICATE_STYLE_PROFILES.sql
@@ -1,0 +1,93 @@
+-- =====================================================
+-- DUBBELE STYLE_PROFILES OPRUIMEN
+-- =====================================================
+--
+-- WAAROM DIT BESTAAT
+--
+-- profileSyncService controleerde met een query zonder LIMIT of er al een
+-- profiel bestond. Had een gebruiker meer dan een rij, dan gaf die query een
+-- fout in plaats van data, concludeerde de code "nog geen profiel" en deed een
+-- INSERT. Elke sync legde er zo een rij bij. Sinds de fix (.limit(1) op alle
+-- style_profiles-queries) groeit dit niet meer, en pakt de app altijd de
+-- nieuwste rij. Bestaande dubbelen breken dus niets meer.
+--
+-- Opruimen is daarom OPTIONEEL. Doe het voor een schonere database en
+-- snellere queries, niet omdat er iets stuk is.
+--
+-- LET OP: style_embedding_snapshots heeft een foreign key naar
+-- style_profiles(id) met ON DELETE CASCADE. Snapshots die aan een verwijderde
+-- profielrij hangen, gaan mee. Dat is historie van hoe een voorkeur zich
+-- ontwikkelde, geen actieve data.
+--
+-- =====================================================
+
+-- STAP 1: kijken hoe groot het is. Verandert niets.
+
+SELECT
+  COUNT(*)                                        AS totaal_rijen,
+  COUNT(DISTINCT user_id) FILTER (WHERE user_id IS NOT NULL) AS unieke_gebruikers,
+  COUNT(*) FILTER (WHERE user_id IS NULL)         AS anonieme_rijen
+FROM style_profiles;
+
+-- STAP 2: de tien gebruikers met de meeste dubbelen. Verandert niets.
+
+SELECT
+  user_id,
+  COUNT(*)          AS aantal_rijen,
+  MIN(created_at)   AS oudste,
+  MAX(created_at)   AS nieuwste
+FROM style_profiles
+WHERE user_id IS NOT NULL
+GROUP BY user_id
+HAVING COUNT(*) > 1
+ORDER BY COUNT(*) DESC
+LIMIT 10;
+
+-- STAP 3: precies zien wat straks weggaat. Verandert niets.
+
+WITH genummerd AS (
+  SELECT
+    id,
+    user_id,
+    created_at,
+    ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at DESC, id DESC) AS positie
+  FROM style_profiles
+  WHERE user_id IS NOT NULL
+)
+SELECT COUNT(*) AS wordt_verwijderd
+FROM genummerd
+WHERE positie > 1;
+
+-- =====================================================
+-- STAP 4: opruimen. DIT VERWIJDERT RIJEN.
+--
+-- Draai dit als een blok. Het staat in een transactie met ROLLBACK aan het
+-- eind, dus de eerste keer verandert er nog niets: je ziet alleen wat het zou
+-- doen. Klopt het aantal met stap 3, vervang dan ROLLBACK door COMMIT en
+-- draai het opnieuw.
+-- =====================================================
+
+BEGIN;
+
+WITH genummerd AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at DESC, id DESC) AS positie
+  FROM style_profiles
+  WHERE user_id IS NOT NULL
+)
+DELETE FROM style_profiles
+WHERE id IN (SELECT id FROM genummerd WHERE positie > 1);
+
+-- Controle: hier hoort per gebruiker nog exact een rij te staan.
+SELECT COUNT(*) AS gebruikers_met_dubbelen
+FROM (
+  SELECT user_id
+  FROM style_profiles
+  WHERE user_id IS NOT NULL
+  GROUP BY user_id
+  HAVING COUNT(*) > 1
+) x;
+
+ROLLBACK;
+-- Vervang de regel hierboven door COMMIT; als de aantallen kloppen.

--- a/src/components/dashboard/RefineStyleWidget.tsx
+++ b/src/components/dashboard/RefineStyleWidget.tsx
@@ -29,6 +29,8 @@ export function RefineStyleWidget() {
             .from('style_profiles')
             .select('visual_preference_skipped, visual_preference_completed_at')
             .eq('user_id', user.id)
+            .order('created_at', { ascending: false })
+            .limit(1)
             .maybeSingle();
 
           if (profile) {

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -217,7 +217,7 @@ export default function AdminDashboardPage() {
               >
                 <Activity className="w-8 h-8 mb-2 opacity-80" />
                 <div className="text-2xl font-bold mb-1">
-                  {loading ? <span className="inline-block w-8 h-7 bg-white/30 rounded animate-pulse" /> : (metrics?.growth.last_7d || 0)}
+                  {loading ? <span className="inline-block w-8 h-7 bg-white/30 rounded animate-pulse" /> : (metrics?.growth?.last_7d || 0)}
                 </div>
                 <div className="text-sm opacity-90">Actief (7d)</div>
               </motion.div>
@@ -230,7 +230,7 @@ export default function AdminDashboardPage() {
               >
                 <Award className="w-8 h-8 mb-2 opacity-80" />
                 <div className="text-2xl font-bold mb-1">
-                  {loading ? <span className="inline-block w-8 h-7 bg-white/30 rounded animate-pulse" /> : (metrics?.tier_breakdown.premium || 0)}
+                  {loading ? <span className="inline-block w-8 h-7 bg-white/30 rounded animate-pulse" /> : (metrics?.tier_breakdown?.premium || 0)}
                 </div>
                 <div className="text-sm opacity-90">Premium Users</div>
               </motion.div>
@@ -243,7 +243,7 @@ export default function AdminDashboardPage() {
               >
                 <TrendingUp className="w-8 h-8 mb-2 opacity-80" />
                 <div className="text-2xl font-bold mb-1">
-                  {loading ? <span className="inline-block w-10 h-7 bg-white/30 rounded animate-pulse" /> : `${(metrics?.total_users ? (metrics.engagement.with_quiz_completed / metrics.total_users) * 100 : 0).toFixed(0)}%`}
+                  {loading ? <span className="inline-block w-10 h-7 bg-white/30 rounded animate-pulse" /> : `${(metrics?.total_users ? ((metrics.engagement?.with_quiz_completed ?? 0) / metrics.total_users) * 100 : 0).toFixed(0)}%`}
                 </div>
                 <div className="text-sm opacity-90">Quiz Completion</div>
               </motion.div>

--- a/src/pages/AdminPWADashboard.tsx
+++ b/src/pages/AdminPWADashboard.tsx
@@ -320,7 +320,7 @@ WHERE email = '${user?.email || 'jouw@email.com'}';`}
           <StatCard
             icon={TrendingUp}
             label="Gem. Click Rate"
-            value={`${stats?.avg_click_rate.toFixed(1)}%`}
+            value={`${(stats?.avg_click_rate ?? 0).toFixed(1)}%`}
             color="accent"
           />
         </div>

--- a/src/pages/OnboardingFlowPage.tsx
+++ b/src/pages/OnboardingFlowPage.tsx
@@ -489,6 +489,7 @@ export default function OnboardingFlowPage() {
           .select('id')
           .eq('user_id', user.id)
           .order('created_at', { ascending: false })
+          .limit(1)
           .maybeSingle();
         existingProfile = data;
       }
@@ -527,6 +528,7 @@ export default function OnboardingFlowPage() {
 
       const { data: verifyData, error: verifyError } = await verifyQuery
         .order('created_at', { ascending: false })
+        .limit(1)
         .maybeSingle();
 
       if (verifyError || !verifyData) return false;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -140,6 +140,7 @@ const ProfilePage: React.FC = () => {
         .select("*")
         .eq("user_id", user.id)
         .order("created_at", { ascending: false })
+        .limit(1)
         .maybeSingle();
       return data;
     },

--- a/src/services/admin/__tests__/dashboardMetrics.test.ts
+++ b/src/services/admin/__tests__/dashboardMetrics.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regressietest voor de crash van het admin-dashboard.
+ *
+ * Repro: een admin opent /admin. De RPC `get_dashboard_metrics` slaagt,
+ * dus `metrics` is een object en het dashboard rendert de vier tegels.
+ * Tegel 2 leest `metrics?.growth.last_7d`. De optional chain dekt alleen
+ * `metrics`, niet `growth`. Sinds migratie
+ * 20251103103800_20251103_fix_dashboard_metrics_recursion.sql levert de
+ * functie een plattere payload zonder `growth`, `engagement`, `referrals`
+ * en `admin_count`, dus `undefined.last_7d` gooit een TypeError tijdens de
+ * render. De ErrorBoundary vangt de hele pagina af: "Er ging iets mis".
+ * Elke keer opnieuw, want de payload is altijd hetzelfde.
+ *
+ * De fix zit in de service: die vertaalt beide payload-vormen naar één
+ * compleet DashboardMetrics-object, zodat de UI nooit meer op een
+ * ontbrekende sleutel stuit.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: () => null,
+}));
+
+import { normalizeDashboardMetrics } from '@/services/admin/adminService';
+
+/** Wat get_dashboard_metrics() vandaag teruggeeft (migratie 20251103103800). */
+const HUIDIGE_PAYLOAD = {
+  total_users: 240,
+  premium_users: 18,
+  active_users_last_7_days: 31,
+  quiz_completion_rate: 0.25,
+  tier_breakdown: { free: 210, premium: 12, founder: 6 },
+};
+
+/** Wat de UI verwachtte: de vorm van migratie 20251020135118. */
+const LEGACY_PAYLOAD = {
+  total_users: 240,
+  admin_count: 3,
+  tier_breakdown: { free: 210, premium: 12, founder: 6 },
+  growth: { last_7d: 31, last_30d: 88, last_90d: 140 },
+  engagement: { with_style_profile: 90, with_saved_outfits: 40, with_quiz_completed: 60 },
+  referrals: { users_with_referrals: 12, total_referrals: 20 },
+};
+
+describe('normalizeDashboardMetrics', () => {
+  it('legt vast waarom het dashboard crashte: de huidige payload heeft geen growth', () => {
+    expect((HUIDIGE_PAYLOAD as Record<string, unknown>).growth).toBeUndefined();
+    expect(() => (HUIDIGE_PAYLOAD as any).growth.last_7d).toThrow(TypeError);
+  });
+
+  it('vult de huidige payload aan tot een compleet object', () => {
+    const m = normalizeDashboardMetrics(HUIDIGE_PAYLOAD);
+
+    expect(m).not.toBeNull();
+    expect(m!.total_users).toBe(240);
+    // active_users_last_7_days is de nieuwe naam van growth.last_7d
+    expect(m!.growth.last_7d).toBe(31);
+    expect(m!.growth.last_30d).toBe(0);
+    expect(m!.tier_breakdown.premium).toBe(12);
+    // 0.25 van 240 gebruikers = 60 afgeronde quiz-afrondingen
+    expect(m!.engagement.with_quiz_completed).toBe(60);
+    expect(m!.referrals.total_referrals).toBe(0);
+  });
+
+  it('laat de legacy payload ongemoeid', () => {
+    const m = normalizeDashboardMetrics(LEGACY_PAYLOAD);
+
+    expect(m!.admin_count).toBe(3);
+    expect(m!.growth).toEqual({ last_7d: 31, last_30d: 88, last_90d: 140 });
+    expect(m!.engagement.with_quiz_completed).toBe(60);
+    expect(m!.referrals).toEqual({ users_with_referrals: 12, total_referrals: 20 });
+  });
+
+  it('overleeft een lege of onverwachte payload zonder te gooien', () => {
+    for (const payload of [{}, { total_users: 'veel' }, [], 'kapot']) {
+      const m = normalizeDashboardMetrics(payload);
+      expect(m!.total_users).toBe(0);
+      expect(m!.growth.last_7d).toBe(0);
+      expect(m!.tier_breakdown.founder).toBe(0);
+      expect(m!.engagement.with_quiz_completed).toBe(0);
+    }
+  });
+
+  it('geeft null terug als er geen payload is', () => {
+    expect(normalizeDashboardMetrics(null)).toBeNull();
+    expect(normalizeDashboardMetrics(undefined)).toBeNull();
+  });
+
+  it('rekent geen quiz-percentage uit zonder gebruikers', () => {
+    const m = normalizeDashboardMetrics({ total_users: 0, quiz_completion_rate: 0.5 });
+    expect(m!.engagement.with_quiz_completed).toBe(0);
+  });
+});

--- a/src/services/admin/adminService.ts
+++ b/src/services/admin/adminService.ts
@@ -47,6 +47,69 @@ export interface AuditLogEntry {
   created_at: string;
 }
 
+function getal(waarde: unknown): number {
+  return typeof waarde === 'number' && Number.isFinite(waarde) ? waarde : 0;
+}
+
+function tak(bron: Record<string, unknown>, sleutel: string): Record<string, unknown> {
+  const waarde = bron[sleutel];
+  return waarde !== null && typeof waarde === 'object' && !Array.isArray(waarde)
+    ? (waarde as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Maakt van de RPC-payload altijd een compleet DashboardMetrics-object.
+ *
+ * `get_dashboard_metrics` is twee keer van vorm veranderd. De versie van
+ * migratie 20251020135118 leverde geneste `growth`, `engagement`, `referrals`
+ * en `admin_count`; de recursie-fix van 20251103103800 gooide die weg en gaf
+ * er `active_users_last_7_days` en `quiz_completion_rate` voor terug. De UI
+ * las nog de oude vorm en crashte op de nieuwe. Deze functie leest beide, en
+ * vult wat de database niet meer levert met nul in plaats van undefined.
+ *
+ * Exported zodat de regressietest hem los kan aanroepen.
+ */
+export function normalizeDashboardMetrics(raw: unknown): DashboardMetrics | null {
+  if (raw === null || raw === undefined) return null;
+
+  const bron: Record<string, unknown> =
+    typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  const tiers = tak(bron, 'tier_breakdown');
+  const groei = tak(bron, 'growth');
+  const betrokkenheid = tak(bron, 'engagement');
+  const referrals = tak(bron, 'referrals');
+
+  const totaalGebruikers = getal(bron.total_users);
+  const quizRatio = getal(bron.quiz_completion_rate);
+
+  return {
+    total_users: totaalGebruikers,
+    admin_count: getal(bron.admin_count),
+    tier_breakdown: {
+      free: getal(tiers.free),
+      premium: getal(tiers.premium),
+      founder: getal(tiers.founder),
+    },
+    growth: {
+      last_7d: getal(groei.last_7d) || getal(bron.active_users_last_7_days),
+      last_30d: getal(groei.last_30d),
+      last_90d: getal(groei.last_90d),
+    },
+    engagement: {
+      with_style_profile: getal(betrokkenheid.with_style_profile),
+      with_saved_outfits: getal(betrokkenheid.with_saved_outfits),
+      with_quiz_completed:
+        getal(betrokkenheid.with_quiz_completed) || Math.round(quizRatio * totaalGebruikers),
+    },
+    referrals: {
+      users_with_referrals: getal(referrals.users_with_referrals),
+      total_referrals: getal(referrals.total_referrals),
+    },
+  };
+}
+
 export async function getDashboardMetrics(): Promise<DashboardMetrics | null> {
   try {
     const sb = supabase();
@@ -56,7 +119,7 @@ export async function getDashboardMetrics(): Promise<DashboardMetrics | null> {
       console.error('Failed to fetch dashboard metrics:', error);
       return null;
     }
-    return data as DashboardMetrics;
+    return normalizeDashboardMetrics(data);
   } catch (err) {
     console.error('Exception fetching dashboard metrics:', err);
     return null;

--- a/src/services/ai/novaService.ts
+++ b/src/services/ai/novaService.ts
@@ -130,6 +130,8 @@ export async function* streamChat(opts: NovaStreamOpts): AsyncGenerator<string, 
           .from('style_profiles')
           .select('*')
           .eq('user_id', userId)
+          .order('created_at', { ascending: false })
+          .limit(1)
           .maybeSingle();
 
         if (profile && !error) {

--- a/src/services/data/__tests__/profileSyncLimit.test.ts
+++ b/src/services/data/__tests__/profileSyncLimit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regressietest voor de 500 op style_profiles.
+ *
+ * De faalende request was:
+ *   GET /rest/v1/style_profiles?select=*&user_id=eq.<uuid>&order=created_at.desc
+ * Geen `limit`. De code eromheen doet wel `.maybeSingle()`, dus de bedoeling
+ * is "pak het nieuwste profiel". Zonder `.limit(1)` haalt PostgREST alle
+ * profielrijen van die gebruiker op, met alle kolommen: quiz_answers,
+ * color_analysis, visual_preference_embedding en locked_embedding.
+ *
+ * Dat gaat op drie manieren mis, en ze versterken elkaar:
+ *
+ *  1. postgrest-js lost `maybeSingle()` op een GET client-side op. Bij meer
+ *     dan één rij geeft het PGRST116 terug in plaats van data. Het profiel
+ *     wordt dus niet hersteld.
+ *  2. syncLocalToRemote gebruikt diezelfde query om te kijken of er al een
+ *     profiel bestaat. Faalt die, dan denkt de sync "nog geen profiel" en
+ *     doet een INSERT. Elke sync legt er zo een rij bij.
+ *  3. Die groeiende set rijen wordt daarna elke paginalading integraal
+ *     opgehaald, inclusief embeddings.
+ *
+ * De fix is `.limit(1)` op elke plek waar het nieuwste profiel wordt gezocht.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const opgevraagd: { tabel: string; limiet: number | null; volgorde: string | null }[] = [];
+
+/** Minimale namaak van de postgrest query builder: onthoudt wat er gevraagd is. */
+function nepQuery(tabel: string, rijen: unknown[]) {
+  const staat = { tabel, limiet: null as number | null, volgorde: null as string | null };
+  opgevraagd.push(staat);
+
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: () => builder,
+    order: (kolom: string) => {
+      staat.volgorde = kolom;
+      return builder;
+    },
+    limit: (n: number) => {
+      staat.limiet = n;
+      return builder;
+    },
+    maybeSingle: async () => {
+      // Precies het gedrag van postgrest-js: meer dan één rij is een fout.
+      if (staat.limiet === null && rijen.length > 1) {
+        return {
+          data: null,
+          error: {
+            code: 'PGRST116',
+            message: 'JSON object requested, multiple (or no) rows returned',
+            details: `Results contain ${rijen.length} rows`,
+          },
+        };
+      }
+      return { data: rijen[0] ?? null, error: null };
+    },
+  };
+  return builder;
+}
+
+/** Deze gebruiker heeft drie profielrijen, zoals een account dat de quiz vaker deed. */
+const DRIE_RIJEN = [
+  { id: 'nieuwste', quiz_answers: { a: 1 }, completed_at: '2026-08-01T00:00:00Z' },
+  { id: 'ouder', quiz_answers: { a: 1 }, completed_at: '2026-05-01T00:00:00Z' },
+  { id: 'oudste', quiz_answers: { a: 1 }, completed_at: '2026-01-01T00:00:00Z' },
+];
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: () => ({
+    from: (tabel: string) => nepQuery(tabel, DRIE_RIJEN),
+    auth: { getUser: async () => ({ data: { user: { id: 'gebruiker-1' } } }) },
+  }),
+}));
+
+vi.mock('@/utils/sessionId', () => ({ getSessionId: () => 'sessie-1' }));
+
+const opslag = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => opslag.get(k) ?? null,
+  setItem: (k: string, v: string) => void opslag.set(k, v),
+  removeItem: (k: string) => void opslag.delete(k),
+  clear: () => opslag.clear(),
+});
+
+import { profileSyncService } from '@/services/data/profileSyncService';
+
+describe('profileSyncService haalt altijd één profiel op', () => {
+  beforeEach(() => {
+    opgevraagd.length = 0;
+    opslag.clear();
+  });
+
+  it('vraagt bij restoreForUser om precies één rij', async () => {
+    await profileSyncService.restoreForUser('gebruiker-1');
+
+    const query = opgevraagd.find(q => q.tabel === 'style_profiles');
+    expect(query).toBeDefined();
+    expect(query!.volgorde).toBe('created_at');
+    expect(query!.limiet).toBe(1);
+  });
+
+  it('herstelt het profiel ook als de gebruiker meerdere profielrijen heeft', async () => {
+    // Vóór de fix gaf maybeSingle hier PGRST116 en viel het herstel stil terug
+    // op het lokale profiel. Nu komt de nieuwste rij gewoon binnen.
+    const hersteld = await profileSyncService.restoreForUser('gebruiker-1');
+    expect(hersteld).toBe(true);
+    expect(opslag.get('ff_sync_status')).toBe('synced');
+  });
+
+  it('vraagt bij getProfile om precies één rij', async () => {
+    await profileSyncService.getProfile();
+
+    const query = opgevraagd.find(q => q.tabel === 'style_profiles');
+    expect(query!.limiet).toBe(1);
+  });
+});

--- a/src/services/data/profileSyncService.ts
+++ b/src/services/data/profileSyncService.ts
@@ -55,6 +55,7 @@ class ProfileSyncService {
           .select('*')
           .eq('user_id', userId)
           .order('created_at', { ascending: false })
+          .limit(1)
           .maybeSingle();
 
         if (error || !data) return false;
@@ -97,6 +98,7 @@ class ProfileSyncService {
           .select('*')
           .eq('user_id', user.id)
           .order('created_at', { ascending: false })
+          .limit(1)
           .maybeSingle();
 
         if (error) {
@@ -162,6 +164,7 @@ class ProfileSyncService {
             .select('*')
             .eq('session_id', sessionId)
             .order('created_at', { ascending: false })
+            .limit(1)
             .maybeSingle();
 
           if (error) {
@@ -252,6 +255,7 @@ class ProfileSyncService {
           .select('id')
           .eq('user_id', user.id)
           .order('created_at', { ascending: false })
+          .limit(1)
           .maybeSingle();
         existingProfile = data;
       }

--- a/src/services/nova/userContext.ts
+++ b/src/services/nova/userContext.ts
@@ -68,6 +68,7 @@ export async function fetchUserContext(
         .select("*")
         .eq("session_id", sessionId)
         .order("created_at", { ascending: false })
+        .limit(1)
         .maybeSingle();
 
       if (error) {
@@ -84,6 +85,7 @@ export async function fetchUserContext(
       .select("*")
       .eq("user_id", userId)
       .order("created_at", { ascending: false })
+      .limit(1)
       .maybeSingle();
 
     if (error) {

--- a/src/services/styleProfile/styleProfileGenerator.ts
+++ b/src/services/styleProfile/styleProfileGenerator.ts
@@ -661,6 +661,8 @@ export class StyleProfileGenerator {
         .from('style_profiles')
         .select('color_analysis, photo_url')
         .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(1)
         .maybeSingle();
 
       if (error) {

--- a/src/utils/migrateQuizToDatabase.ts
+++ b/src/utils/migrateQuizToDatabase.ts
@@ -55,6 +55,8 @@ export async function migrateQuizToDatabase(): Promise<{ success: boolean; error
       .from('style_profiles')
       .select('id')
       .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
       .maybeSingle();
 
     if (existingProfile) {


### PR DESCRIPTION
Twee losse fouten in het adminkanaal, allebei met een regressietest.

## 1. Het admin-dashboard crashte bij elke load

`get_dashboard_metrics` is op 3 november herschreven (migratie `20251103103800_..._fix_dashboard_metrics_recursion.sql`) en levert sindsdien een plattere payload: geen `growth`, `engagement`, `referrals` of `admin_count` meer, maar `active_users_last_7_days` en `quiz_completion_rate`.

De frontend is nooit meegegaan. `AdminDashboardPage` las `metrics?.growth.last_7d`, waarbij de optional chain alleen `metrics` dekt en niet `growth`. Zodra de RPC slaagde, gooide de render een TypeError en verving de ErrorBoundary het hele dashboard door "Er ging iets mis". Elke keer, want de payload is altijd dezelfde.

`adminService` vertaalt nu beide payloadvormen naar een compleet object, dus dit werkt of de database nu de oude of de nieuwe functie heeft.

## 2. Elf queries op style_profiles zonder limit(1)

De faalende request was `GET /rest/v1/style_profiles?select=*&user_id=eq.<uuid>&order=created_at.desc`, met een 500 tot gevolg. Geen `limit`, terwijl de code eromheen wel `.maybeSingle()` doet. Er werd dus gevraagd om alle profielrijen van een gebruiker met alle kolommen, inclusief `quiz_answers`, `color_analysis`, `visual_preference_embedding` en `locked_embedding`.

Deze call zit in `UserContext`, dus hij draait op elke pagina waar iemand ingelogd is.

Daarbovenop een lus: `syncLocalToRemote` gebruikte dezelfde query om te controleren of er al een profiel bestond. Faalde die, dan concludeerde de code "nog geen profiel" en deed een INSERT in plaats van een UPDATE. Elke sync legde er een rij bij, dus het probleem groeide mee met de leeftijd van een account.

`.limit(1)` staat nu op alle elf plekken, plus een `order` op de vier die er geen hadden zodat "de nieuwste" ook echt de nieuwste is.

## Opruimen

`CLEANUP_DUPLICATE_STYLE_PROFILES.sql` ruimt de opgebouwde dubbele rijen op. Optioneel: met `.limit(1)` pakt de app altijd de nieuwste rij, dus bestaande dubbelen breken niets meer. Het script telt eerst, laat zien wat er weggaat en eindigt op ROLLBACK.

## Verificatie

- `npx tsc --noEmit` schoon
- `npx vitest run` 219 tests groen, 18 bestanden
- `npx vite build` draait door

Beide fixes hebben een test die rood was voor de wijziging en groen erna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)